### PR TITLE
Change Eclipse to Eclipse IDE

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/introduction-presentation.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/introduction-presentation.adoc
@@ -75,7 +75,7 @@ If you are using Mac OS X make sure the version is greater than 10.11.x (Captain
 
 This workshop will make use of the following software, tools, frameworks that you will need to install and now (more or less) how it works:
 
-* Any IDE you feel comfortable with (eg. Intellij IDEA, Eclipse, VS Code..)
+* Any IDE you feel comfortable with (eg. Intellij IDEA, Eclipse IDE, VS Code..)
 * JDK 8
 * GraalVM 19.2.0.1
 * Maven 3.6.x


### PR DESCRIPTION
Hello, first, thanks for the workshop.

I am an Eclipse IDE user, and I notice the name used about the IDE is not enough precise. Since few years now, the "correct" name of the IDE from Eclipse Foundation is `Eclipse IDE`. See https://www.eclipse.org/eclipseide/ 

I checked in the entire repository, it seems you only use the term in `introduction-presentation.adoc`