### PR TITLE
Qualify 'openapi' extension name to avoid conflict

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/rest-openapi.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/rest-openapi.adoc
@@ -47,7 +47,7 @@ To install the OpenAPI dependency, just run the following command:
 
 [source,shell]
 ----
-$ ./mvnw quarkus:add-extension -Dextensions="openapi"
+$ ./mvnw quarkus:add-extension -Dextensions="smallrye-openapi"
 ----
 
 This will add the following dependency in the `pom.xml` file:

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fight/bootstrap.sh
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fight/bootstrap.sh
@@ -6,5 +6,5 @@ mvn io.quarkus:quarkus-maven-plugin:1.2.0.Final:create \
     -DclassName="io.quarkus.workshop.superheroes.fight.FightResource" \
     -Dpath="api/fights"
 cd rest-fight
-./mvnw quarkus:add-extension -Dextensions="jdbc-postgresql,hibernate-orm-panache,hibernate-validator,quarkus-resteasy-jsonb,openapi,kafka"
+./mvnw quarkus:add-extension -Dextensions="jdbc-postgresql,hibernate-orm-panache,hibernate-validator,quarkus-resteasy-jsonb,smallrye-openapi,kafka"
 # end::adocSnippet[]


### PR DESCRIPTION
 * 'openapi' does no longer seem specific enough as it refers to both
   'io.quarkus:quarkus-smallrye-openapi' and
   'org.apache.camel.quarkus:camel-quarkus-rest-openapi'