### PR TITLE
Update to Quarkus 1.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,40 +5,29 @@ on:
     branches:
       - master
 
-jobs:
-  build_java8:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install JDK 1.8
-      uses: joschi/setup-jdk@v1.0.0
-      with:
-        java-version: 'openjdk8'
-    - name: Build with Maven
-      run: mvn -B clean install--file quarkus-workshop-super-heroes/pom.xml
-
+jobs:  
   build_java11:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Install JDK 11
-        uses: joschi/setup-jdk@v1.0.0
+        uses: AdoptOpenJDK/install-jdk@v1.1.0
         with:
-          java-version: 'openjdk11'
+          version: '11'
       - name: Build with Maven
         run: mvn -B clean install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true
 
         # GITHUB_API_TOKEN
 
   publication:
-    needs: [build_java8, build_java11]
+    needs: [build_java11]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Install JDK 11
-        uses: joschi/setup-jdk@v1.0.0
+        uses: AdoptOpenJDK/install-jdk@v1.1.0
         with:
-          java-version: 'openjdk11'
+          version: '11'
       - name: Site generation
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,26 +2,15 @@ name: Pull Request
 
 on: pull_request
 
-jobs:
-  build_java8:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install JDK 1.8
-      uses: joschi/setup-jdk@v1.0.0
-      with:
-        java-version: 'openjdk8'
-    - name: Build with Maven
-      run: mvn -B clean install --file quarkus-workshop-super-heroes/pom.xml
-
+jobs:  
   build_java11:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Install JDK 11
-        uses: joschi/setup-jdk@v1.0.0
+        uses: AdoptOpenJDK/install-jdk@v1.1.0
         with:
-          java-version: 'openjdk11'
+          version: '11'
       - name: Build with Maven
         run: mvn -B clean install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node/
 .project
 .classpath
 .settings
+.factorypath

--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/extension.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/extension.adoc
@@ -56,7 +56,7 @@ include::{github-raw}/extensions/extension-banner/bootstrap.sh[tag=adocSnippet]
 
 This script creates the structure for the banner extension:
 
-* one parent `pom.xml` importing the `quarkus-bom` and the `quarkus-bom-deployment`
+* one parent `pom.xml` importing the `quarkus-bom`
 * a module for the runtime
 * a module for the deployment, with a dependency on the runtime artifact
 

--- a/quarkus-workshop-super-heroes/extensions/extension-banner/bootstrap.sh
+++ b/quarkus-workshop-super-heroes/extensions/extension-banner/bootstrap.sh
@@ -29,13 +29,6 @@ echo "<project xmlns='http://maven.apache.org/POM/4.0.0' xmlns:xsi='http://www.w
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom-deployment</artifactId>
-                <version>\${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/quarkus-workshop-super-heroes/extensions/extension-banner/bootstrap.sh
+++ b/quarkus-workshop-super-heroes/extensions/extension-banner/bootstrap.sh
@@ -40,7 +40,7 @@ echo "<project xmlns='http://maven.apache.org/POM/4.0.0' xmlns:xsi='http://www.w
     </dependencyManagement>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/quarkus-workshop-super-heroes/extensions/extension-banner/pom.xml
+++ b/quarkus-workshop-super-heroes/extensions/extension-banner/pom.xml
@@ -48,14 +48,7 @@
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom-deployment</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            </dependency>            
         </dependencies>
     </dependencyManagement>
 </project>

--- a/quarkus-workshop-super-heroes/extensions/extension-banner/pom.xml
+++ b/quarkus-workshop-super-heroes/extensions/extension-banner/pom.xml
@@ -31,7 +31,7 @@
     </modules>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/quarkus-workshop-super-heroes/extensions/extension-fault-injector/pom.xml
+++ b/quarkus-workshop-super-heroes/extensions/extension-fault-injector/pom.xml
@@ -27,7 +27,7 @@
     <name>Quarkus Workshop :: Extensions :: Fault Injector Extension</name>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/quarkus-workshop-super-heroes/extensions/extension-fault-injector/pom.xml
+++ b/quarkus-workshop-super-heroes/extensions/extension-fault-injector/pom.xml
@@ -44,14 +44,7 @@
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom-deployment</artifactId>
-                <version>${quarkus.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
+            </dependency>            
         </dependencies>
     </dependencyManagement>
 

--- a/quarkus-workshop-super-heroes/super-heroes/event-statistics/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/event-statistics/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fight/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fight/pom.xml
@@ -25,7 +25,7 @@
     <name>Quarkus Workshop :: Super-Heroes :: Fight REST API</name>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-villain/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-villain/pom.xml
@@ -25,7 +25,7 @@
     <name>Quarkus Workshop :: Super-Heroes :: Villain REST API</name>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/pom.xml
@@ -25,7 +25,7 @@
     <name>Quarkus Workshop :: Super-Heroes :: Super Heroes UI</name>
 
     <properties>
-        <quarkus.version>1.5.0.Final</quarkus.version>
+        <quarkus.version>1.7.0.Final</quarkus.version>
         <surefire-plugin.version>2.22.0</surefire-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Update workshop to Quarkus 1.7.0:

In addition:

- Add  .factorypath to .gitignore
- Remove Java 8 build and switch to AdoptOpenJDK
