### PR TITLE
Fix build by using AdoptOpenJDK/install-jdk@v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1.1.0
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
       - name: Build with Maven
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1.1.0
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
       - name: Site generation

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1.1.0
+        uses: AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
       - name: Build with Maven


### PR DESCRIPTION
Like this it uses the latest v1 tag (which is v1.1.1).
In this version the deprecation-warning (eg. the removal of the set-env function) is resolved (see https://github.com/AdoptOpenJDK/install-jdk/releases/tag/v1.1.1)