### PR TITLE
Fixe timeout value to be consistant with the code.

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/5-rest-client/timeout.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/5-rest-client/timeout.adoc
@@ -51,7 +51,7 @@ When the process is really too long and the system is overloaded, we would rathe
 
 icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 
-Note that the timeout was configured to 250 ms, and a `Thread.sleep` was introduced and can be configured in the `application.properties`.
+Note that the timeout was configured to 500 ms, and a `Thread.sleep` was introduced and can be configured in the `application.properties`.
 If we set the property to a higher value than the timeout, let's say 10.000, then the request should be interrupted.
 
 [source]


### PR DESCRIPTION
Little inconsistance between the doc and the code.