### PR TITLE
Cleanup ApplicationScoped usage

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/1-rest/rest-bootstrapping.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/1-rest/rest-bootstrapping.adoc
@@ -199,10 +199,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import javax.enterprise.context.ApplicationScoped;
-
 @Path("/api/villains")
-@ApplicationScoped
 public class VillainResource {
 
     @GET

--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/1-rest/rest-openapi.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/1-rest/rest-openapi.adoc
@@ -214,7 +214,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.validation.Valid;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -234,7 +233,6 @@ import static javax.ws.rs.core.MediaType.*;
 
 @Path("/api/villains")
 @Tag(name="villains")
-@ApplicationScoped
 public class VillainResource {
 
     Logger logger;

--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/1-rest/rest-orm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/1-rest/rest-orm.adoc
@@ -348,7 +348,6 @@ package io.quarkus.workshop.superheroes.villain;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.validation.Valid;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -364,7 +363,6 @@ import java.util.List;
 import static javax.ws.rs.core.MediaType.*;
 
 @Path("/api/villains")
-@ApplicationScoped
 public class VillainResource {
 
     Logger logger;

--- a/quarkus-workshop-super-heroes/docs/src/main/asciidoc/3-reactive/reactive.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/main/asciidoc/3-reactive/reactive.adoc
@@ -239,7 +239,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.RestPath;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
@@ -250,7 +249,6 @@ import static javax.ws.rs.core.MediaType.*;
 
 @Path("/api/heroes")
 @Tag(name = "heroes")
-@ApplicationScoped
 public class HeroResource {
 
     Logger logger;


### PR DESCRIPTION
Cleanup of ApplicationScoped usage. It isn't needed in resource classes.