### PR TITLE
Fix test executions in heroes and fix few typos

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-docker.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-docker.adoc
@@ -21,6 +21,8 @@ Installation instructions are available on the following page:
 
 On Linux, don't forget the post-execution steps described on https://docs.docker.com/install/linux/linux-postinstall/.
 
+NOTE: If you are on the latest versions of Fedora, you might prefer `podman` (https://podman.io/) instead of `docker`. To install `podman` and `podman-compose` on Fedora please follow the instructions at https://fedoramagazine.org/manage-containers-with-podman-compose/. You will also need to configure testcontainers library used in Dev Services later in the workshop like mentioned in https://quarkus.io/blog/quarkus-devservices-testcontainers-podman/#tldr.
+
 == Checking for Docker Installation
 
 Once installed, check that both `docker` and `docker compose` are available in your `PATH`:

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/3-reactive/reactive.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/3-reactive/reactive.adoc
@@ -6,7 +6,7 @@
 Quarkus combines the build time principle with a reactive core.
 The combination of these two characteristics improve the application concurrency and use resources more efficiently.
 In this chapter, we will see the counterpart of the Villain microservice: the Hero microservice!
-Instead of the imperative approach uses for the villains, we will use reactive programming and Hibernate Reactive.
+Instead of the imperative approach used for the villains, we will use reactive programming and Hibernate Reactive.
 The logic of the microservice is the same.
 
 [plantuml,align=center,width=300]
@@ -484,7 +484,7 @@ public class HeroResourceTest {
             .when().get("/api/heroes/random")
             .then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON);
+            .contentType(APPLICATION_JSON);
     }
 
     @Test
@@ -511,7 +511,7 @@ public class HeroResourceTest {
     void shouldGetInitialItems() {
         List<Hero> heroes = get("/api/heroes").then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .extract().body().as(getHeroTypeRef());
         assertEquals(NB_HEROES, heroes.size());
     }
@@ -578,7 +578,7 @@ public class HeroResourceTest {
             .put("/api/heroes")
             .then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .body("name", Is.is(UPDATED_NAME))
             .body("otherName", Is.is(UPDATED_OTHER_NAME))
             .body("level", Is.is(UPDATED_LEVEL))
@@ -587,7 +587,7 @@ public class HeroResourceTest {
 
         List<Hero> heroes = get("/api/heroes").then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .extract().body().as(getHeroTypeRef());
         assertEquals(NB_HEROES + 1, heroes.size());
     }
@@ -603,7 +603,7 @@ public class HeroResourceTest {
 
         List<Hero> heroes = get("/api/heroes").then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .extract().body().as(getHeroTypeRef());
         assertEquals(NB_HEROES, heroes.size());
     }

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-fight.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-fight.adoc
@@ -638,7 +638,7 @@ public class FightResourceTest {
 ----
 
 Quarkus automatically starts the PostGreSQL database as well as a Kafka broker.
-Also, delete the generated `NativeFightResourceIT` class, as we won't run native tests.
+Also, delete the generated `FightResourceIT` native test class, as we won't run native tests.
 
 == Running, Testing and Packaging the Application
 

--- a/quarkus-workshop-super-heroes/super-heroes/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroResourceTest.java
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroResourceTest.java
@@ -81,7 +81,7 @@ public class HeroResourceTest {
             .when().get("/api/heroes/random")
             .then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON);
+            .contentType(APPLICATION_JSON);
     }
 
     @Test
@@ -108,7 +108,7 @@ public class HeroResourceTest {
     void shouldGetInitialItems() {
         List<Hero> heroes = get("/api/heroes").then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .extract().body().as(getHeroTypeRef());
         assertEquals(NB_HEROES, heroes.size());
     }
@@ -175,7 +175,7 @@ public class HeroResourceTest {
             .put("/api/heroes")
             .then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .body("name", Is.is(UPDATED_NAME))
             .body("otherName", Is.is(UPDATED_OTHER_NAME))
             .body("level", Is.is(UPDATED_LEVEL))
@@ -184,7 +184,7 @@ public class HeroResourceTest {
 
         List<Hero> heroes = get("/api/heroes").then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .extract().body().as(getHeroTypeRef());
         assertEquals(NB_HEROES + 1, heroes.size());
     }
@@ -200,7 +200,7 @@ public class HeroResourceTest {
 
         List<Hero> heroes = get("/api/heroes").then()
             .statusCode(OK.getStatusCode())
-            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .contentType(APPLICATION_JSON)
             .extract().body().as(getHeroTypeRef());
         assertEquals(NB_HEROES, heroes.size());
     }


### PR DESCRIPTION
Add note about podman

Just for the context, the problem with tests is introduced in 2.9.1:

```
[ERROR]   HeroResourceTest.shouldGetInitialItems:106 1 expectation failed.
Expected header "Content-Type" was not "application/json", was "application/json;charset=UTF-8". Headers are:
transfer-encoding=chunked
Content-Type=application/json;charset=UTF-8
```