### PR TITLE
Fix broken 'Alternatives' link

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/rest-clients.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/rest-clients.adoc
@@ -234,7 +234,7 @@ But, now we have another problem.
 To run the tests of the Fight API we need the Hero and Villain REST APIs to be up and running.
 To avoid this, we need to Mock the `HeroProxy` and `VillainProxy` interfaces.
 
-Quarkus supports the use of mock objects using the CDI `@Alternative` mechanism.footnote:[Alternatives https://docs.jboss.org/weld/reference/latest/en-US/html/beanscdi.html#_alternatives]
+Quarkus supports the use of mock objects using the CDI `@Alternative` mechanism.footnote:[Alternatives https://docs.jboss.org/weld/reference/latest/en-US/html/specialization.html#_using_alternative_stereotypes]
 
 icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 


### PR DESCRIPTION
'Alternatives' link is not available anymore : 
![image](https://user-images.githubusercontent.com/11772429/232865359-5c74f8fc-0bc9-4c04-a199-77bc0ad6384c.png)



The address changed from https://docs.jboss.org/weld/reference/latest/en-US/html/beanscdi.html#_alternatives to https://docs.jboss.org/weld/reference/latest/en-US/html/specialization.html#_using_alternative_stereotypes
