### PR TITLE
Avoid hardcoded URLs by leveraging CI environment variables

### DIFF
--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -31,9 +31,11 @@
         <version.asciidoctorj>2.5.3</version.asciidoctorj>
         <version.asciidoctorj.pdf>1.6.2</version.asciidoctorj.pdf>
         <version.asciidoctorj.diagram>2.2.1</version.asciidoctorj.diagram>
-        <github.raw>https://raw.githubusercontent.com/quarkusio/quarkus-workshops/main/quarkus-workshop-super-heroes</github.raw>
-        <github.url>https://github.com/quarkusio/quarkus-workshops/tree/main/quarkus-workshop-super-heroes</github.url>
-        <github.issue>https://github.com/quarkusio/quarkus-workshops/issues</github.issue>
+        <!-- If building docs locally and urls matter, set environment variables for these values -->
+        <github.raw>https://raw.githubusercontent.com/${env.GITHUB_REPOSITORY}/${env.GITHUB_REF}/quarkus-workshop-super-heroes</github.raw>
+        <github.url>${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/tree/${env.GITHUB_REF}/quarkus-workshop-super-heroes</github.url>
+        <github.repo>${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}</github.repo>
+        <github.issue>${github.repo}/issues</github.issue>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
@@ -79,9 +81,10 @@
                         <allow-uri-read/>
                         <icons>font</icons>
                         <imagesdir>../images</imagesdir>
-                        <plantDir> ../plantuml</plantDir>
+                        <plantDir>../plantuml</plantDir>
                         <github-raw>${github.raw}</github-raw>
                         <github-url>${github.url}</github-url>
+                        <github-repo>${github.repo}</github-repo>
                         <github-issue>${github.issue}</github-issue>
                         <give-solution>true</give-solution>
                         <jdk-version>${maven.compiler.source}</jdk-version>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-openapi.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-openapi.adoc
@@ -337,7 +337,7 @@ icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 
 For this, you need to create the `src/main/java/io/quarkus/workshop/superheroes/villain/VillainApplication` class with the following content:
 
-[source,java]
+[source,java,subs="attributes+"]
 ----
 package io.quarkus.workshop.superheroes.villain;
 
@@ -359,7 +359,7 @@ import javax.ws.rs.core.Application;
     servers = {
         @Server(url = "http://localhost:8084")
     },
-    externalDocs = @ExternalDocumentation(url = "https://github.com/quarkusio/quarkus-workshops", description = "All the Quarkus workshops")
+    externalDocs = @ExternalDocumentation(url = "{github-repo}", description = "All the Quarkus workshops")
 )
 public class VillainApplication extends Application {
     // Empty body
@@ -375,7 +375,7 @@ icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 
 If you go back to the `http://localhost:8084/q/openapi` endpoint you will see the following OpenAPI contract:
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 ---
 openapi: 3.0.3
@@ -388,7 +388,7 @@ info:
   version: "1.0"
 externalDocs:
   description: All the Quarkus workshops
-  url: https://github.com/quarkusio/quarkus-workshops
+  url: {github-repo}
 servers:
 - url: http://localhost:8084
 tags:

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-intro-preparing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-intro-preparing.adoc
@@ -9,11 +9,11 @@ Here are a few commands that you can execute before the workshop.
 
 icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 
-First, clone the GitHub repository of the Super Heroes application located at https://github.com/quarkusio/quarkus-workshops by executing the following command:
+First, clone the GitHub repository of the Super Heroes application located at {github-url} by executing the following command:
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
-git clone https://github.com/quarkusio/quarkus-workshops.git --depth 1
+git clone {github-repo}.git --depth 1
 ----
 
 The code of this Super Heroes application is separated into two different directories:


### PR DESCRIPTION
The hardcoded URLs in the `pom.xml` cause problems in forks of this workshop. We probably won't have many forks (although I have one), but I think there's also relatively downside to making the URLs more dynamic. If we're building from CI we get the values for free. Locally, we'd need to use environment variables, which might be slightly annoying. 

(If we find it too annoying I could put a fallback into the pom which hardcodes the values to the original URL if environment variables aren't present.)