### PR TITLE
More thorough CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,28 +8,31 @@ on:
       - 'quarkus-workshop-super-heroes/**'
       - '.github/**'
 jobs:
-  build_java11:
+  build_java17:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install JDK 11
+      - name: Install JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
-      - name: Build with Maven
-        run: mvn -B clean install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
-
+          java-version: 17
+      - name: Skeleton build with Maven
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
+      - name: Microservices build with Maven
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pcomplete
+      - name: Extension build with Maven
+        run: mvn -B install -f quarkus-workshop-super-heroes/super-heroes/extension-version/pom.xml
   publication:
-    needs: [ build_java11 ]
+    needs: [ build_java17 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install JDK 11
+      - name: Install JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Site generation
         run: |
           sudo apt-get install graphviz

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,15 +8,19 @@ on:
       - '.github/**'
 
 jobs:
-  build_java11:
+  build_java17:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install JDK 11
+      - name: Install JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
-      - name: Build with Maven
-        run: mvn -B clean install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
+          java-version: 17
+      - name: Skeleton build with Maven
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
+      - name: Microservices build with Maven
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pcomplete
+      - name: Extension build with Maven
+        run: mvn -B install -f quarkus-workshop-super-heroes/super-heroes/extension-version/pom.xml
 

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -8,27 +8,31 @@ on:
       - 'quarkus-workshop-super-heroes/docs/**'
       - 'quarkus-workshop-super-heroes/dist/**'
 jobs:
-  build_java11:
+  build_java17:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install JDK 11
+      - name: Install JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
-      - name: Build with Maven
-        run: mvn -B clean install --file quarkus-workshop-super-heroes/pom.xml
+          java-version: 17
+      - name: Skeleton build with Maven
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
+      - name: Microservices build with Maven
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pcomplete
+      - name: Extension build with Maven
+        run: mvn -B install -f quarkus-workshop-super-heroes/super-heroes/extension-version/pom.xml
   publication:
-    needs: [ build_java11 ]
+    needs: [ build_java17 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install JDK 11
+      - name: Install JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Generate zips
         run: |
           cd quarkus-workshop-super-heroes/


### PR DESCRIPTION
I noticed the CI isn't actually building everything, so breaks can go unnoticed. To build everything, the `complete` profile is needed, and then extra builds are needed for the docs and extension. This isn't what I'd expect, but I assume there's a good reason for it, so I've left as-is and just updated the CI to be more thorough.

When I started building the modules in the CI I noticed that the CI is using Java 11, but some of the modules, like Villains, are now using Java 17. I've updated to Java 17 in the CI. 