### PR TITLE
Instructions and code fixes for native UI

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing.adoc
@@ -31,7 +31,7 @@ quarkus-workshop-super-heroes
 === Super Heroes Application
 
 Under the `super-heroes` directory you will find the entire Super Hero application spread throughout a set of subdirectories, each one containing a microservice or some tooling.
-The final structure will be the following:
+The final structure will be the following (don't worry if you don't have all this yet, this is what we're aiming towards):
 
 [plantuml]
 ----

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-ui.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-ui.adoc
@@ -82,3 +82,19 @@ Check localhost:8080, and your new content should appear.
 
 You can also change the javascript code.
 For example, try updating the text in `src/main/webui/src/app/app.component.ts`.
+
+== Native compilation and Quinoa
+
+You can compile the UI application as a native binary, just like other Quarkus applications.
+
+icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+
+Try compiling natively with
+
+----
+./mvnw package -Pnative
+./target/ui-super-heroes-1.0.0-SNAPSHOT-runner
+----
+
+The native compilation will take a while, but once it's done, the UI will start in around 0.02s.
+You can confirm it's working by checking http://localhost:8080.

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/java/io/quarkus/workshop/superheroes/ui/Config.java
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/java/io/quarkus/workshop/superheroes/ui/Config.java
@@ -1,4 +1,12 @@
 package io.quarkus.workshop.superheroes.ui;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/*
+Why do we need to register this for reflection? Normally this would be automatic if
+we return it from a REST endpoint, but because we're handling our own
+object mapping, we need to do our own registering.
+ */
+@RegisterForReflection
 public record Config(String API_BASE_URL, boolean CALCULATE_API_BASE_URL) {
 }

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/java/io/quarkus/workshop/superheroes/ui/Config.java
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/java/io/quarkus/workshop/superheroes/ui/Config.java
@@ -1,5 +1,7 @@
 package io.quarkus.workshop.superheroes.ui;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /*
@@ -7,6 +9,7 @@ Why do we need to register this for reflection? Normally this would be automatic
 we return it from a REST endpoint, but because we're handling our own
 object mapping, we need to do our own registering.
  */
+@JsonNaming(PropertyNamingStrategies.UpperSnakeCaseStrategy.class)
 @RegisterForReflection
-public record Config(String API_BASE_URL, boolean CALCULATE_API_BASE_URL) {
+public record Config(String apiBaseUrl, boolean calculateApiBaseUrl) {
 }


### PR DESCRIPTION
One of the cool things about using Quinoa for the UI module is we can build a native executable for the UI. This PR adds instructions for doing that, and also fixes a native break which happens because of some inside-method object-mapping.