### PR TITLE
Use relative path for redirect

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/redirect.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/redirect.html
@@ -1,8 +1,8 @@
 <html>
     <head>
-        <meta http-equiv="refresh" content="0; url=https://quarkus.io/quarkus-workshops/super-heroes/index.html" />
+        <meta http-equiv="refresh" content="0; url=super-heroes/index.html"/>
     </head>
     <body>
-        <p><a href="https://quarkus.io/quarkus-workshops/super-heroes/index.html">Redirect</a></p>
+        <p><a href="super-heroes/index.html">Redirect</a></p>
     </body>
 </html>


### PR DESCRIPTION
I sometimes run the workshop from a fork, with the URL of http://hollycummins.com/quarkus-workshops. Sadly, that link redirects to quarkus.io/quarkus-workshops/super-heroes. In order to avoid the redirect I need to link more directly to http://hollycummins.com/quarkus-workshops/super-heroes/. 

The hardcoded URL doesn't actually need to be in the redirect, so I have fixed (and validated in my fork that the redirect still works). 