### PR TITLE
Add jbangcatalog and make qrcode more resilient

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,11 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "qrcode": {
+      "script-ref": "quarkus-workshop-super-heroes/docs/src/resource-generation/qrcode.java",
+      "enable-preview": false,
+      "java-agents": []
+    }
+  },
+  "templates": {}
+}

--- a/quarkus-workshop-super-heroes/docs/src/resource-generation/qrcode.java
+++ b/quarkus-workshop-super-heroes/docs/src/resource-generation/qrcode.java
@@ -32,7 +32,7 @@ class qrcode {
             System.exit(1);
         } else {
             String text = args[0];
-            String filePath = args[1];
+            String filePath = args.length>1?args[1]:"qrcode.png";
             int width = 640;
             writeQrCode(text, filePath, width);
         }
@@ -87,6 +87,7 @@ class qrcode {
         g.drawImage(overlay, woffset, hoffset,
             null);
 
+        System.out.println("Writing QR code to " + filePath);
         ImageIO.write(combined, "png", new File(filePath));
     }
 


### PR DESCRIPTION
Why:

 * its tedious to write: `jbang https://github.com/quarkusio/quarkus-workshops/blob/main/quarkus-workshop-super-heroes/docs/src/resource-generation/qrcode.java https://shattereddisk.github.io/rickroll/ mycode.png`
* would much rather just do: `jbang qrcode@quarkusio/quarkus-workshops https://shattereddisk.github.io/rickroll` and have the filename be optional. or simply `jbang qrcode https://shattereddisk.github.io/rickroll mycode.png` anywhere within the repo.

This change addreses the need by:

 * add `jbang-catalog.json` to the repo made using `jbang alias add -f . quarkus-workshop-super-heroes/docs/src/resource-generation/qrcode.java`
* made `qrcode.java` default the file name to avoid having to specify it and to avoid exception thrown.