### PR TITLE
Produce different versions of the workshop for different OSes 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
           mvn install
           
           # make an index.html
-          cp target/generated-asciidoc/spine.html target/generated-asciidoc/index.html
           cp target/generated-asciidoc/spine-azure.html target/generated-asciidoc/index-azure.html
 
           # Move things around to preserve the super-heroes structure

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -98,9 +98,19 @@
                         <require>asciidoctor-diagram</require>
                     </requires>
                     <relativeBaseDir>true</relativeBaseDir>
+                    <preserveDirectories>true</preserveDirectories>
+                    <backend>html</backend>
+                    <sourceDocumentName>spine.adoc</sourceDocumentName>
+                    <outputDirectory>${project.build.directory}/generated-asciidoc</outputDirectory>
                     <attributes>
                         <!-- Allows access to remote files (e.g. code on external GitHub) -->
                         <allow-uri-read/>
+                        <imagesdir>images</imagesdir>
+                        <toc>left</toc>
+                        <linkcss>false</linkcss>
+                        <docinfo1>true</docinfo1>
+                        <icons>font</icons>
+                        <toclevels>3</toclevels>
                         <icons>font</icons>
                         <imagesdir>../images</imagesdir>
                         <plantDir>../plantuml</plantDir>
@@ -125,17 +135,8 @@
                             <goal>process-asciidoc</goal>
                         </goals>
                         <configuration>
-                            <preserveDirectories>true</preserveDirectories>
-                            <outputDirectory>${project.build.directory}/generated-asciidoc</outputDirectory>
-                            <backend>html</backend>
-                            <sourceDocumentName>spine.adoc</sourceDocumentName>
                             <attributes>
                                 <imagesdir>images</imagesdir>
-                                <toc>left</toc>
-                                <linkcss>false</linkcss>
-                                <docinfo1>true</docinfo1>
-                                <icons>font</icons>
-                                <toclevels>3</toclevels>
                             </attributes>
                         </configuration>
                     </execution>
@@ -146,17 +147,9 @@
                             <goal>process-asciidoc</goal>
                         </goals>
                         <configuration>
-                            <preserveDirectories>true</preserveDirectories>
-                            <outputDirectory>${project.build.directory}/generated-asciidoc</outputDirectory>
-                            <backend>html</backend>
                             <sourceDocumentName>spine-azure.adoc</sourceDocumentName>
                             <attributes>
                                 <imagesdir>images</imagesdir>
-                                <toc>left</toc>
-                                <linkcss>false</linkcss>
-                                <docinfo1>true</docinfo1>
-                                <icons>font</icons>
-                                <toclevels>3</toclevels>
                             </attributes>
                         </configuration>
                     </execution>

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -141,6 +141,51 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>output-html-linux</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-asciidoc/linux</outputDirectory>
+                            <attributes>
+                                <imagesdir>images</imagesdir>
+                                <use-windows>false</use-windows>
+                                <use-mac>false</use-mac>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>output-html-mac</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-asciidoc/mac</outputDirectory>
+                            <attributes>
+                                <imagesdir>images</imagesdir>
+                                <use-windows>false</use-windows>
+                                <use-linux>false</use-linux>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>output-html-windows</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-asciidoc/windows</outputDirectory>
+                            <attributes>
+                                <imagesdir>images</imagesdir>
+                                <use-mac>false</use-mac>
+                                <use-linux>false</use-linux>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>output-html-azure</id>
                         <phase>generate-resources</phase>
                         <goals>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-curl.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-curl.adoc
@@ -8,6 +8,7 @@ It is free, open-source (available under the MIT Licence), and has been ported t
 
 == Installing cURL
 
+ifdef::use-mac[]
 If you are on Mac OS X and have installed Homebrew, then installing cURL is just a matter of a single command.footnote:[Homebrew https://brew.sh]
 Open your terminal and install cURL with the following command:
 
@@ -15,8 +16,11 @@ Open your terminal and install cURL with the following command:
 ----
 brew install curl
 ----
+endif::use-mac[]
 
+ifdef::use-windows[]
 For Windows, download and install curl from https://curl.se/download.html.
+endif::use-windows[]
 
 == Checking for cURL Installation
 
@@ -70,7 +74,7 @@ curl http://localhost:8083/api/heroes
 But what we want is to format the JSON payload, so it is easier to read.
 For that, there is a neat utility tool called `jq` that we could use.
 `jq` is a tool for processing JSON inputs, applying the given filter to its JSON text inputs, and producing the filter's results as JSON on standard output.footnote:[jq https://stedolan.github.io/jq]
-You can install it on Mac OSX with a simple `brew install jq`.
+ifdef::use-mac[You can install it on Mac OSX with a simple `brew install jq`.]
 Once installed, it's just a matter of piping the cURL output to jq like this:
 
 [source,shell]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-docker.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-docker.adoc
@@ -20,14 +20,20 @@ Our infrastructure will use Docker to ease the installation of the different tec
 So for this, we need to install `docker` and `docker compose`
 Installation instructions are available on the following page:
 
+ifdef::use-mac[]
 * Mac OS X - https://docs.docker.com/docker-for-mac/install/ (version 20+)
+endif::use-mac[]
+ifdef::use-windows[]
 * Windows - https://docs.docker.com/docker-for-windows/install/ (version 20+)
+endif::use-windows[]
+ifdef::use-linux[]
 * CentOS - https://docs.docker.com/install/linux/docker-ce/centos/
 * Debian - https://docs.docker.com/install/linux/docker-ce/debian/
 * Fedora - https://docs.docker.com/install/linux/docker-ce/fedora/
 * Ubuntu - https://docs.docker.com/install/linux/docker-ce/ubuntu/
 
 On Linux, don't forget the post-execution steps described on https://docs.docker.com/install/linux/linux-postinstall/.
+endif::use-linux[]
 
 NOTE: If you do not have a Docker licence, you might prefer `podman` (https://podman.io/) instead of `docker`. To install `podman` and `podman-compose` on Fedora please follow the instructions at https://fedoramagazine.org/manage-containers-with-podman-compose/. You will also need to configure testcontainers library used in Dev Services later in the workshop like mentioned in https://quarkus.io/blog/quarkus-devservices-testcontainers-podman/#tldr.
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-git.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-git.adoc
@@ -6,6 +6,7 @@ Git{wj}footnote:[Git https://git-scm.com] is a free and open source distributed 
 It is primarily used for source code management in software development, but it can be used to keep track of changes in any set of files.
 Git was created by Linus Torvalds in 2005 for the development of the Linux kernel, with other kernel developers contributing to its initial development.
 
+ifdef::use-mac[]
 == Installing Git
 
 On Mac, if you have installed Homebrew, then installing Git is just a matter of a single command.
@@ -15,6 +16,7 @@ Open your terminal and install Git with the following command:
 ----
 $ brew install git
 ----
+endif::use-mac[]
 
 == Checking for Git Installation
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-graalvm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-graalvm.adoc
@@ -9,6 +9,7 @@ One objective of GraalVM is to improve the performance of Java virtual machine-b
 
 === Prerequisites for GraalVM
 
+ifdef::use-linux[]
 On Linux, you need GCC and the Glibc and zlib headers.
 Examples for common distributions:
 
@@ -19,16 +20,21 @@ sudo dnf install gcc glibc-devel zlib-devel
 # Debian-based distributions:
 sudo apt-get install build-essential libz-dev zlib1g-dev
 ----
+endif::use-linux[]
 
+ifdef::use-mac[]
 On macOS X, XCode provides the required dependencies to build native executables:
 
 [source,shell]
 ----
 xcode-select --install
 ----
+endif::use-mac[]
 
+ifdef::use-windows[]
 On Windows, you need the _Developer Command Prompt for Microsoft Visual C++_.
 Check the https://www.graalvm.org/docs/getting-started/windows/#prerequisites-for-using-native-image-on-windows[Windows prerequisites page] for details.
+endif::use-windows[]
 
 === Installing GraalVM
 
@@ -39,9 +45,15 @@ Select the {jdk-version} version.
 
 Follow the installation instructions:
 
+ifdef::use-linux[]
 - Linux - https://www.graalvm.org/docs/getting-started/linux/
+endif::use-linux[]
+ifdef::use-windows[]
 - Windows - https://www.graalvm.org/docs/getting-started/windows/
+endif::use-windows[]
+ifdef::use-mac[]
 - MacOS - https://www.graalvm.org/docs/getting-started/macos/
+endif::use-mac[]
 
 Once installed, define the `GRAALVM_HOME` environment variable to point to the directory where GraalVM is installed (eg. on Mac OS X it could be /Library/Java/JavaVirtualMachines/graalvm-ce-{graalvm-version}/Contents/Home).
 
@@ -55,6 +67,7 @@ gu install native-image
 
 from your GraalVM `bin` directory.
 
+ifdef::use-mac[]
 [NOTE]
 .Mac OS X - Catalina
 ====
@@ -67,6 +80,7 @@ To bypass the issue, it is recommended to run the following command instead of d
 xattr -r -d com.apple.quarantine ${GRAAL_VM}
 -----
 ====
+endif::use-mac[]
 
 === Checking for GraalVM Installation
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-jdk.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-jdk.adoc
@@ -10,6 +10,7 @@ The code in this workshop uses JDK {jdk-version}.
 
 To install the JDK {jdk-version}, follows the instructions from https://adoptium.net/installation.html to download and install the JDK for your platform.
 
+ifdef::use-mac[]
 There is also an easier way to download and install Java if you are on Mac OS X.
 You can use Homebrew to install OpenJDK {jdk-version} using the following commands.footnote:[Homebrew https://brew.sh]
 
@@ -17,7 +18,9 @@ You can use Homebrew to install OpenJDK {jdk-version} using the following comman
 ----
 brew install java17
 ----
+endif::use-mac[]
 
+ifdef::use-linux[]
 For Linux distributions, there are also packaged java installations.
 [source,shell]
 ----
@@ -26,6 +29,7 @@ dnf install java-17-openjdk
 # Debian-based distributions:
 $ apt-get install openjdk-17-jdk
 ----
+endif::use-linux[]
 
 == Checking for Java Installation
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-maven.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-maven.adoc
@@ -14,12 +14,14 @@ Once you have installed JDK {jdk-version}, make sure the `JAVA_HOME` environment
 Then, download Maven from http://maven.apache.org/, unzip the file on your hard drive and add the `apache-maven/bin` directory to your `PATH` variable.
 More details about the installation process are available on https://maven.apache.org/install.html.
 
+ifdef::use-mac[]
 But of course, if you are on Mac OS X and use Homebrew, install Maven with the following command:
 
 [source,shell]
 ----
 brew install maven
 ----
+endif::use-mac[]
 
 == Checking for Maven Installation
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-maven.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-installing-maven.adoc
@@ -10,12 +10,14 @@ With an extensible architecture based on plugins, Maven can offer many different
 == Installing Maven
 
 The examples of this workshop have been developed with Apache Maven {maven-version}.
+ifdef::use-windows,use-linux[]
 Once you have installed JDK {jdk-version}, make sure the `JAVA_HOME` environment variable is set.
 Then, download Maven from http://maven.apache.org/, unzip the file on your hard drive and add the `apache-maven/bin` directory to your `PATH` variable.
 More details about the installation process are available on https://maven.apache.org/install.html.
+endif::use-windows,use-linux[]
 
 ifdef::use-mac[]
-But of course, if you are on Mac OS X and use Homebrew, install Maven with the following command:
+If you are on Mac OS X and use Homebrew, install Maven with the following command:
 
 [source,shell]
 ----

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing-warming-docker.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing-warming-docker.adoc
@@ -2,7 +2,11 @@
 = Warming up Docker images
 
 To warm up your Docker image repository, navigate to the `quarkus-workshop-super-heroes/super-heroes/infrastructure` directory.
-Here, you will find a `docker-compose.yaml`/`docker-compose-linux.yaml` files which define all the needed Docker images.
+Here, you will find a
+ifdef::use-mac,use-windows[`docker-compose.yaml`]
+ifdef::use-mac+use-linux[ or ]
+ifdef::use-linux[`docker-compose-linux.yaml`]
+file which defines all the needed Docker images.
 Notice that there is a `db-init` directory with an `initialize-databases.sql` script which sets up our databases, and a `monitoring` directory (all that will be explained later).
 
 icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
@@ -11,14 +15,21 @@ Then execute the following command which will download all the Docker images and
 
 [source,shell]
 ----
+ifdef::use-mac,use-windows[]
 docker compose -f docker-compose.yaml up -d
+endif::use-mac,use-windows[]
+ifndef::use-mac,use-windows[]
+docker compose -f docker-compose-linux.yaml up -d
+endif::use-mac,use-windows[]
 ----
 
+ifdef::use-linux[]
 [WARNING]
 .Linux Users beware
 ====
 If you are on Linux, use `docker-compose-linux.yaml` instead of `docker-compose.yaml`. This Linux specific file will allow Prometheus to fetch metrics from the services running on the host machine.
 ====
+endif::use-linux[]
 
 [WARNING]
 ====

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-presentation.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-presentation.adoc
@@ -76,10 +76,12 @@ Oh, and be ready to have some fun!
 
 First of all, make sure you have a 64bits computer with admin rights (so you can install all the needed tools) and at least 8Gb of RAM (as some tools need a few resources).
 
+ifdef::use-mac[]
 [WARNING]
 ====
-If you are using Mac OS X, make sure the version is greater than 10.11.x (Captain).
+If you are using Mac OS X, make sure the version is greater than 10.11.x (El Capitan).
 ====
+endif::use-mac[]
 
 This workshop will make use of the following Software, tools, frameworks that you will need to install and now (more or less) how it works:
 
@@ -97,5 +99,5 @@ You can skip the next section if you have already installed all the prerequisite
 [WARNING]
 ====
 This workshop assumes a bash shell.
-If you run on Windows, in particular, adjust the commands accordingly.
+ifdef::use-windows[If you run on Windows, in particular, adjust the commands accordingly.]
 ====

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction.adoc
@@ -26,7 +26,9 @@ Well, it's going to be a set of microservices:
 
 This workshop is a BYOL (_Bring Your Own Laptop_) session, so bring your Windows, OSX, or Linux laptop.
 You need JDK {jdk-version} on your machine, Apache Maven ({maven-version}), and Docker.
+ifdef::use-mac,use-windows[]
 On Mac and Windows, Docker for _x_ is recommended instead of the Docker toolbox setup.
+endif::[]
 
 What you are going to learn:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-orm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-orm.adoc
@@ -795,6 +795,7 @@ icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 Now, just execute `docker compose -f docker-compose.yaml up -d`.
 You should see a few logs going on and then all the containers get started.
 
+ifdef::use-linux[]
 On Linux, use the `docker-compose-linux.yaml`:
 
 [source,shell]
@@ -802,11 +803,16 @@ On Linux, use the `docker-compose-linux.yaml`:
 ----
 docker compose -f docker-compose-linux.yaml up -d
 ----
+ifdef::use-linux[]
 
 [NOTE]
 ====
 During the workshop, just leave all the containers up and running.
-Then, after the workshop, remember to shut them down using: `docker compose -f docker-compose.yaml down` or  `docker compose -f docker-compose-linux.yaml down` on Linux.
+Then, after the workshop, remember to shut them down using: `docker compose -f docker-compose.yaml down`
+ifdef::use-linux[]
+ or  `docker compose -f docker-compose-linux.yaml down` on Linux
+endif::use-linux[]
+.
 ====
 
 === Packaging and running the application

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-prometheus.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-prometheus.adoc
@@ -23,6 +23,7 @@ Make sure the infrastructure is up and running.
 This means that you've executed `docker compose -f docker-compose.yaml up -d`.
 ====
 
+ifdef::use-linux[]
 [NOTE]
 .On Linux / Ubuntu
 ====
@@ -30,6 +31,7 @@ On Linux, you may need to update the `localhost` from the `prometheus-linux.yml`
 Find the address, update the `prometheus-linux.yml` and restart the infrastructure.
 Don't forget to restart the microservices to re-populate the databases.
 ====
+endif::use-linux[]
 
 == Adding Graphs to Prometheus
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -138,3 +138,7 @@ span.red.big {
 pre code, pre pre {
   font-size: 14px;
 }
+
+ul.configurator {
+  list-style-type: none;
+}

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Quarkus Super-Heroes Workshop</title>
+        <link rel="stylesheet"
+              href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+        <meta name="keywords" content="Quarkus, Workshop, Microservice, Kafka">
+        <meta name="description" content="A hands on lab about Quarkus">
+
+        <link href="assets/css/bootstrap.css" media="screen" rel="stylesheet">
+        <link href="assets/css/font-awesome.min.css" media="screen" rel="stylesheet">
+        <link href="assets/css/hol.css" media="screen" rel="stylesheet">
+        <link href="assets/css/github.css" media="screen" rel="stylesheet">
+        <script src="assets/js/jquery-3.1.1.js"></script>
+        <script src="assets/js/bootstrap.js"></script>
+    </head>
+    <title>Workshop configurator</title>
+    <script>
+        // Use relative URLs
+        const baseUrl = "./";
+        const filename = "spine.html"
+
+        function generateDefaultURL() {
+            const url = baseUrl + filename
+            window.location.href = url;
+        }
+
+        function generateURL() {
+            const selectedOptions = [];
+
+            // Get the selected build option
+            const osOption = document.querySelector('input[name="osOption"]:checked');
+
+            const osValue = osOption.value;
+
+            selectedOptions.push(osValue);
+
+            // Generate the URL based on selected options
+            const url = baseUrl + selectedOptions.join("/") + "/" + filename;
+            window.location.href = url;
+
+        }
+    </script>
+</head>
+<body>
+<h1>Quarkus Workshop Configurator</h1>
+
+<button onclick="generateDefaultURL()">Just take me to the default workshop</button>
+
+<h2>What kind of workshop would you like?</h2>
+
+<h3>What operating system are you using?</h3>
+<ul class="configurator">
+    <li>
+        <label for="macRadio">
+            <input type="radio" name="osOption" id="macRadio" value="mac"> MacOS
+        </label>
+    </li>
+    <li>
+        <label for="windowsRadio">
+            <input type="radio" name="osOption" id="windowsRadio" value="windows"> Windows
+        </label>
+    </li>
+    <li>
+        <label for="linuxRadio">
+            <input type="radio" name="osOption" id="linuxRadio" value="linux"> Linux
+        </label></li>
+</ul>
+<br>
+
+<button onclick="generateURL()">Customise my workshop</button>
+<br/>
+
+</body>
+</html>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -21,6 +21,11 @@ v2.0, {docdate}: Quarkus {quarkus-version}
 :half-width: role=half-width
 :half-size: role=half-size
 
+// Conditional includes - can be overridden in the build to generate tailored docs
+:use-mac: true
+:use-linux: true
+:use-windows: true
+
 // Introduction
 include::0-introduction/introduction.adoc[leveloffset=+1]
 include::0-introduction/introduction-presentation.adoc[leveloffset=+2]


### PR DESCRIPTION
The current workshop is quite long, and people need to filter through some information which is not relevant for their OS. We should make the workshop more customisable, with a "choose your own adventure" style setup. 

I've put in a framework to support pre-workshop customisation, which we can extend with more knobs. For the starting knob, I've allowed people to choose an OS. There's also a version of the document which still has all options. 

Sadly, I couldn't find a way to pass live parameters into adoc, except in live preview. Instead, I've generated a static version of the file for each parameter. The combinatorics in the pom.xml for this will be pretty bad once we go above two knobs, so I may need to find a better way. Maybe generated poms? 

Next steps: 

- Extend the parameterisation to the Azure files and spine
- See if we can use similar logic to get rid of the azure spine.html and maybe even the azure introduction (cc @agoncal)
- Extend to gradle (#240), as another knob
- Add a knob for 'workshop length'
- Add a mini-configurator in the ToC so that if people end up on the wrong doc they have a pathway to make it right
- Maybe use [asciidoctor-tabs](https://github.com/asciidoctor/asciidoctor-tabs) to add tabs into the 'all-options' doc
- Where we have a bulleted list and only one option, tidy that up
