### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    open-pull-requests-limit: 10
+    schedule:
+      interval: weekly
+    labels:
+      - "version-upgrade"
+    pull-request-branch-name:
+      separator: "_"


### PR DESCRIPTION
I think there's no reason not to enable dependabot. The noise of PRs will be slightly up to date, but keeping the workshop current will be valuable.