### PR TITLE
Avoid running multiple zip generation builds at the same time

### DIFF
--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build_java17:
     runs-on: ubuntu-latest
+    concurrency: zip-generation
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK 17
@@ -26,6 +27,7 @@ jobs:
   publication:
     needs: [ build_java17 ]
     runs-on: ubuntu-latest
+    concurrency: zip-generation
     steps:
       - uses: actions/checkout@v3
       - name: Install JDK 17


### PR DESCRIPTION
The failure in  https://github.com/quarkusio/quarkus-workshops/actions/runs/5347835093 happened, I think, because a zip build was kicked off and then another merge happened. I'm not sure I can protect against that, but we should at least be able to protect against multiple zip builds happening at the same time. 

This is another PR we can only test post-merge. 
