### PR TITLE
Be DRYer in Call To Action entries

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing-checking-ports.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing-checking-ports.adoc
@@ -3,8 +3,8 @@
 
 During this workshop, we will use several ports.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Just make sure the following ports are free, so you don't run into any conflicts.
 
 [source,shell]
@@ -18,3 +18,4 @@ lsof -i tcp:9090    # Prometheus
 lsof -i tcp:2181    # Zookeeper
 lsof -i tcp:9092    # Kafka
 ----
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing-warming-docker.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing-warming-docker.adoc
@@ -9,7 +9,8 @@ ifdef::use-linux[`docker-compose-linux.yaml`]
 file which defines all the needed Docker images.
 Notice that there is a `db-init` directory with an `initialize-databases.sql` script which sets up our databases, and a `monitoring` directory (all that will be explained later).
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Then execute the following command which will download all the Docker images and start the containers:
 
@@ -22,6 +23,7 @@ ifndef::use-mac,use-windows[]
 docker compose -f docker-compose-linux.yaml up -d
 endif::use-mac,use-windows[]
 ----
+--
 
 ifdef::use-linux[]
 [WARNING]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/0-introduction/introduction-preparing.adoc
@@ -7,7 +7,8 @@ Here are a few commands that you can execute before the workshop.
 
 == Download the workshop scaffolding
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 First, download the zip file  {github-raw}/dist/quarkus-super-heroes-workshop.zip, and unzip it wherever you want.
 This zip file contains _some_ of the code of the workshop, and you will need to complete it.
@@ -27,6 +28,7 @@ quarkus-workshop-super-heroes
 }
 @endsalt
 ----
+--
 
 === Super Heroes Application
 
@@ -81,15 +83,17 @@ include::introduction-preparing-checking-ports.adoc[leveloffset=+1]
 
 == Warming up Maven
 
-Now that you have the initial structure in place, navigate to the root directory and run:
+[example, role="cta"]
+--
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+Now that you have the initial structure in place, navigate to the root directory and run:
 
 
 [source,shell]
 ----
 ./mvnw clean install
 ----
+--
 
 By running this command, it downloads all the required dependencies.
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-bootstrapping.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-bootstrapping.adoc
@@ -9,7 +9,8 @@ That's what you are going to see in this section.
 The easiest way to create a new Quarkus project is to use the Quarkus Maven plugin.
 Open a terminal and run the following command:
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 [source,shell,subs="attributes+"]
 ----
@@ -35,9 +36,9 @@ If you want your IDE to manage this new Maven project, you can declare it in the
 ----
 <module>super-heroes/rest-villains</module>
 ----
-
+--
 [TIP]
-.Preferring Web UI
+.Prefer a Web UI?
 ====
 Instead of the Maven command, you can use https://code.quarkus.io and select the `resteasy-reactive-jackson` extension.
 ====
@@ -222,7 +223,8 @@ NOTE: Methods can also have their own `@Path` annotation suffixed to the class o
 
 == Running the Application
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Now we are ready to run our application.
 
@@ -274,6 +276,7 @@ Hello from RESTEasy Reactive
 ----
 
 Alternatively, you can open http://localhost:8080/api/villains in your browser.
+--
 
 == Development Mode
 
@@ -293,7 +296,8 @@ To check that the hot reload is working, update the `VillainResource.hello()` me
 
 Now, execute the cURL command again:
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 [source,shell]
 ----
@@ -303,6 +307,7 @@ Hello Villain Resource
 ----
 
 The output has changed without you having to stop and restart Quarkus!
+--
 
 == Testing the Application
 
@@ -383,16 +388,18 @@ So in your RestAssured tests, you don't have to specify the default test port 80
 You can also configure the ports used by tests by configuring the `quarkus.http.test-port` property in the application.properties.
 ====
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 In the terminal running the application in _dev mode_, you should see at the bottom:
 
 [source,text]
 ----
---
 Tests paused
 Press [r] to resume testing, [o] Toggle test output, [:] for the terminal, [h] for more options>
 ----
+
+--
 
 Hit the `r` key, and watch Quarkus execute your tests automatically and even continuously.
 Unfortunately, this first run didn't end well:
@@ -489,7 +496,8 @@ You can also run the tests from a terminal using:
 
 == Packaging and Running the Application
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 The application is packaged using the `./mvnw package` command (it also runs the tests).
 That command generates:
@@ -500,6 +508,7 @@ That command generates:
 This _fast jar_ takes advantage of the build-time principle of Quarkus (we discuss it soon) to improve the application performances and which can be easily transposed to container layers.
 
 Stop the application running in dev mode (by hitting `q` or `CTRL+C`), and run the application using: `java -jar target/quarkus-app/quarkus-run.jar`.
+--
 
 [NOTE]
 ====
@@ -532,6 +541,7 @@ Then `sudo vi /etc/hosts` so you have the right to edit the file and add the fol
 ----
 127.0.0.1 localhost my-node.local
 ----
+
 ====
 
 In another terminal, check that the application runs using:

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-configuration.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-configuration.adoc
@@ -25,17 +25,19 @@ quarkus.log.console.darken=1
 Because we will end-up running several microservices, let's configure Quarkus so it listens to a different port than 8080:
 This is quite easy as we just need to add one property in the `application.properties` file:
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 [source,properties]
 ----
 ## HTTP configuration
 quarkus.http.port=8084
 ----
+--
 
 Changing the port is one of the rare configuration that cannot be done while the application is running.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 You would need to restart the application to change the port.
 
@@ -46,6 +48,7 @@ Then run:
 ----
 curl http://localhost:8084/api/villains | jq
 ----
+--
 
 == Injecting Configuration Value
 
@@ -59,14 +62,15 @@ When injecting a configured value, you can use `@Inject @ConfigProperty` or just
 The `@Inject` annotation is not necessary for members annotated with `@ConfigProperty`, a behavior which differs from https://microprofile.io/project/eclipse/microprofile-config[MicroProfile Config].
 ====
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Edit the `VillainService`, and introduce the following configuration properties:
 
 [source,java,indent=0]
 ----
 @ConfigProperty(name = "level.multiplier", defaultValue="1.0") double levelMultiplier;
 ----
+--
 
 [NOTE]
 ====
@@ -76,8 +80,8 @@ You may need to add the following import statement if your IDE does not do it au
 If you do not provide a value for this property, the application startup fails with `jakarta.enterprise.inject.spi.DeploymentException: No config value of type [int] exists for: level.multiplier`.
 To avoid having to configure a value, we configure a default one (property `defaultValue`).
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Now, modify the `VillainService.persistVillain()` method to use the injected properties:
 
 [source,java,indent=0]
@@ -88,24 +92,26 @@ public Villain persistVillain(@Valid Villain villain) {
         return villain;
 }
 ----
+--
 
 == Create the Configuration
 
 By default, Quarkus reads `application.properties`.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Edit the `src/main/resources/application.properties` with the following content:
 
 [source,properties]
 ----
 level.multiplier=0.5
 ----
+--
 
 == Running and Testing the Application
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 If you didn't already, start the application with `./mvnw quarkus:dev`.
 Once started, create a new villain with the following cUrl command:
 
@@ -133,6 +139,7 @@ curl http://localhost:8084/api/villains/582 | jq
   "powers": "Agility, Longevity"
 }
 ----
+--
 
 [NOTE]
 ====
@@ -165,12 +172,12 @@ Indeed, they don't know the multiplier.
 
 TIP: Press `r` in the dev mode to run the tests.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 In the `application.properties` file, add: `%test.level.multiplier=1` which set the multiplier to 1 when running the tests:
 
 [source,text]
 ----
 All 8 tests are passing (0 skipped), 8 tests were run in 1722ms. Tests completed at 21:03:25.
 ----
-
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-openapi.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-openapi.adoc
@@ -41,7 +41,8 @@ super-heroes
 
 Quarkus proposes a `smallrye-openapi` extension compliant with the MicroProfile OpenAPI specification in order to generate your API OpenAPI v3 specification.footnote:[MicroProfile OpenAPI https://github.com/eclipse/microprofile-open-api]
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 To install the OpenAPI dependency, just run the following command:
 
@@ -49,6 +50,7 @@ To install the OpenAPI dependency, just run the following command:
 ----
 ./mvnw quarkus:add-extension -Dextensions="smallrye-openapi"
 ----
+--
 
 This will add the following dependency in the `pom.xml` file:
 
@@ -163,11 +165,11 @@ components:
           type: string
 ----
 
-This contract lacks of documentation.
+This contract lacks documentation.
 The Eclipse MicroProfile OpenAPI allows you to customize the methods of your REST endpoint as well as the application.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 
 While having the OpenAPI specification is great, it can't be consumed easily by humans.
 In your browser, go to http://localhost:8084/q/dev.
@@ -182,6 +184,7 @@ Click on the "_Swagger UI_" button located in the "SmallRye OpenAPI" widget (htt
 You will see all your endpoints listed.
 Click on the "_GET_" button for the "/api/villains" path, then click on "_Try it out_" and finally on "Execute".
 You can see the result immediately.
+--
 
 When developing REST APIs, this UI is very convenient.
 You can test your endpoint and immediately see the outcome.
@@ -190,8 +193,6 @@ If something does not please you, edit the code, go back to the browser, re-exec
 
 === Customizing Methods
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
 The MicroProfile OpenAPI has a set of annotations to customize each REST endpoint method so the OpenAPI contract is richer and clearer for consumers:
 
 * `@Operation`: Describes a single API operation on a path.
@@ -199,7 +200,9 @@ The MicroProfile OpenAPI has a set of annotations to customize each REST endpoin
 * `@Parameter`: The name of the parameter.
 * `@RequestBody`: A brief description of the request body.
 
-This is what the `VillainResource` endpoint looks like once annotated:
+[example, role="cta"]
+--
+This is what the `VillainResource` endpoint should look like once you have annotated it:
 
 [source,java]
 ----
@@ -320,6 +323,7 @@ public class VillainResource {
 
 With this new code, go back to the Swagger UI at http://localhost:8084/q/swagger-ui and refresh.
 Your endpoints are organized by tags, and each annotated endpoint is documented.
+--
 
 Documenting REST API is essential when working with different teams.
 You can see OpenAPI as the JavaDoc for REST.
@@ -332,7 +336,8 @@ But it's also important to document the entire application.
 The Microprofile OpenAPI also has a set of annotation to do so.
 The difference is that these annotations cannot be used on the endpoint methods, but instead on another Java class configuring the entire application.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For this, you need to create the `src/main/java/io/quarkus/workshop/superheroes/villain/VillainApplication` class with the following content:
 
@@ -367,10 +372,12 @@ public class VillainApplication extends Application {
 
 Go back to the Swagger UI and refresh again.
 At the top of the document, you can see the version and the global API documentation.
+--
 
 === Customized Contract
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 If you go back to the `http://localhost:8084/q/openapi` endpoint you will see the following OpenAPI contract:
 
@@ -530,10 +537,12 @@ components:
 ----
 
 You can expose or exchange this contract to the API consumers, so they now what to expect when using your API.
+--
 
 == OpenAPI Tests in VillainResourceTest
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Let's add an extra test method in `VillainResourceTest` ensuring that the OpenAPI specification is packaged with the application:
 
@@ -553,5 +562,7 @@ Run the test:
 
  - From the dev mode, or
  - By executing the test using `./mvnw test`.
+--
 
 include::../common-solution.adoc[]
+

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-orm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/1-rest/rest-orm.adoc
@@ -54,12 +54,13 @@ Because JPA and Bean Validation work well together, we will use Bean Validation 
 
 To add the required dependencies, just run the following command:
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 [source,shell]
 ----
 ./mvnw quarkus:add-extension -Dextensions="jdbc-postgresql,hibernate-orm-panache,hibernate-validator"
 ----
+--
 
 TIP: No need to add an extension for JSON, we already included `resteasy-reactive-jackson`.
 
@@ -89,8 +90,8 @@ From now on, you can choose to either edit your pom directly or use the `quarkus
 
 == Villain Entity
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 To define a Panache entity, simply extend `PanacheEntity`, annotate it with `@Entity` and add your columns as public fields (no need to have getters and setters).
 The `Villain` entity should look like this:
 
@@ -136,6 +137,7 @@ public class Villain extends PanacheEntity {
     }
 }
 ----
+--
 
 Notice that you can put all your JPA column annotations and Bean Validation constraint annotations on the public fields.
 
@@ -166,7 +168,8 @@ long countAll = Villain.count();
 
 But we are missing a business method: we need to return a random villain.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For that it's just a matter to add the following method to our `Villain.java` entity:
 
@@ -179,6 +182,7 @@ public static Villain findRandom() {
     return findAll().page(randomVillain, 1).firstResult();
 }
 ----
+--
 
 [NOTE]
 ====
@@ -198,7 +202,8 @@ We use `quarkus.hibernate-orm.database.generation=drop-and-create` in conjunctio
 This is best to perfectly control your environment and works magic with Quarkus live reload mode:
 your entity changes or any change to your `import.sql` is immediately picked up and the schema updated without restarting the application!
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For that, make sure to have the following configuration in your `application.properties` (located in `src/main/resources`):
 
@@ -207,6 +212,7 @@ For that, make sure to have the following configuration in your `application.pro
 # drop and create the database at startup (use `update` to only update the schema)
 quarkus.hibernate-orm.database.generation=drop-and-create
 ----
+--
 
 == Villain Service
 
@@ -224,8 +230,9 @@ You can control whether and how the transaction is started with parameters on `@
 * `@Transactional(NOT_SUPPORTED)`: if a transaction was started, suspends it and works with no transaction for the boundary of the method ; otherwise works with no transaction.
 * `@Transactional(NEVER)`: if a transaction was started, raises an exception ; otherwise works with no transaction.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 
+[example, role="cta"]
+--
 Creates a new `VillainService.java` file in the same package with the following content:
 
 [source,java]
@@ -286,6 +293,7 @@ public class VillainService {
     }
 }
 ----
+--
 
 The `@ApplicationScoped` annotation declares a _bean_.
 The other component of the application can access this bean.
@@ -301,7 +309,8 @@ Our project now requires a connection to a PostgreSQL database.
 In dev mode, no need to start a database or configure anything.
 Quarkus does that for us (just make sure you have Docker up and running).
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Start the application in dev mode with `./mvnw quarkus:dev`.
 In the log, you will see the following:
@@ -329,6 +338,7 @@ In the log, you will see the following:
 
 2021-09-21 15:58:48,044 INFO  [io.qua.dev.pos.dep.PostgresqlDevServicesProcessor] (build-38) Dev Services for the default datasource (postgresql) started
 ----
+--
 
 Quarkus detects the need for a database and starts one using a Docker container.
 It automatically configures the application, which means we are good to go and implement our REST API.
@@ -352,7 +362,8 @@ This setting will likely also be needed **throughout** the workshop.
 The `VillainResource` was bootstrapped with only one method `hello()`.
 We need to add extra methods that will allow CRUD operations on villains.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Here are the new methods to add to the `VillainResource` class:
 
@@ -449,7 +460,8 @@ public class VillainResource {
 }
 ----
 
-Not that we added `@Path("/hello")` to the `hello` method to not conflict with the `getAllVillains()` method.
+Note that we added `@Path("/hello")` to the `hello` method to not conflict with the `getAllVillains()` method.
+--
 
 == Dependency Injection
 
@@ -503,7 +515,8 @@ VALUES (nextval('villain_seq'), 'The Rival (CW)', 'Edward Clariss',
         10);
 ----
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Ok, but that's just a few entries.
 Download the SQL file {github-raw}/super-heroes/rest-villains/src/main/resources/import.sql[import.sql] and copy it under `src/main/resources`.
@@ -518,14 +531,15 @@ If you didn't yet, start the application in dev mode:
 
 Then, open your browser to http://localhost:8080/api/villains.
 You should see lots of heroes...
+--
 
 == CRUD Tests in VillainResourceTest
 
 To test the `VillainResource` endpoint, we just need to extend the `VillainResourceTest` we already have.
 No need to configure anything, Quarkus will start a test database for you.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 
 In `io.quarkus.workshop.superheroes.villain.VillainResourceTest`, you will add the following test methods to the `VillainResourceTest` class:
 
@@ -742,15 +756,17 @@ public class VillainResourceTest {
 
 }
 ----
+--
 
 The tests and the application runs in the same JVM, meaning that the test can be injected with application _beans_.
 This feature is very useful to test specific parts of the application.
 However, in our case, we just execute HTTP requests to check the result.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Run the test either in the dev mode or using `./mvnw test`.
 They should pass.
+--
 
 == Building production package
 
@@ -767,8 +783,8 @@ In Quarkus, the out of the box datasource and connection pooling implementation 
 So, we need to configure the database access in the `src/main/resources/application.properties` file,
 but only when the application runs in _prod_ mode.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Add the following datasource configuration:
 
 [source,properties]
@@ -778,6 +794,7 @@ Add the following datasource configuration:
 %prod.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/villains_database
 %prod.quarkus.hibernate-orm.sql-load-script=import.sql
 ----
+--
 
 `%prod` indicates that the property is only used when the application runs with the given profile.
 We configure the access to the database, and force the data initialization (which would have been disabled by default in _prod_ mode).
@@ -790,8 +807,8 @@ Let's use Docker and docker compose to ease the installation of such infrastruct
 
 You should already have installed the infrastructure into the `infrastructure` directory.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Now, just execute `docker compose -f docker-compose.yaml up -d`.
 You should see a few logs going on and then all the containers get started.
 
@@ -804,6 +821,7 @@ On Linux, use the `docker-compose-linux.yaml`:
 docker compose -f docker-compose-linux.yaml up -d
 ----
 ifdef::use-linux[]
+--
 
 [NOTE]
 ====
@@ -817,8 +835,8 @@ endif::use-linux[]
 
 === Packaging and running the application
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Stop the dev mode, and run:
 
 [source,shell]
@@ -835,7 +853,7 @@ java -jar target/quarkus-app/quarkus-run.jar
 
 Open your browser to http://localhost:8080/api/villains, and verify it displays the expected content.
 Once done, stop the application using `CTRL+C`.
-
+--
 
 
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-augmentation.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-augmentation.adoc
@@ -7,14 +7,15 @@ So far, you have developed the super-villains microservice.
 This microservice is relatively simple.
 It still has database access, ORM support, transaction, JSON serialization, and deserialization.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Let's now package this application using:
 
 [source,shell]
 ----
 ./mvnw package
 ----
+--
 
 In the log, you can see actions happening during what Quarkus calls the _augmentation_ phase.
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-kubernetes.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-kubernetes.adoc
@@ -20,14 +20,15 @@ It proposes multiple approaches to do so, but we recommend using https://github.
 
 The resulting image follows the container good practices such as the usage of layers, avoiding the `root` user...
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Add the `quarkus-container-image-jib` extension using the following command:
 
 [source, shell]
 ----
 ./mvnw quarkus:add-extension -Dextensions="jib"
 ----
+--
 
 It adds the following dependency to the `pom.xml` file:
 
@@ -39,6 +40,8 @@ It adds the following dependency to the `pom.xml` file:
 </dependency>
 ----
 
+[example, role="cta"]
+--
 Then, launch the following command to build the application and create the container image:
 
 [source, shell]
@@ -53,6 +56,7 @@ Once done, verify that the container image has been created using:
 docker images | grep villains
 .../rest-villains              1.0.0-SNAPSHOT         1298cad04f5e   About a minute ago   388MB
 ----
+--
 
 == Building a container running a native executable
 
@@ -83,7 +87,8 @@ Adapt the instructions for your Kubernetes:
 2. Make sure you use the correct namespace
 ====
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Edit the `src/main/resources/application.properties` to add the following lines:
 
@@ -105,6 +110,7 @@ Add the `quarkus-kubernetes` extension using the following command:
 ----
 ./mvnw quarkus:add-extension -Dextensions="kubernetes"
 ----
+--
 
 TIP: If you are behind a proxy, check the https://quarkus.io/guides/extension-registry-user#how-to-register-as-a-nexus-repository-proxy[Quarkus Registry] proxy documentation.
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-lifecycle.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-lifecycle.adoc
@@ -41,7 +41,8 @@ super-heroes
 
 When our application starts, the logs are dull and lack a banner (any decent application *must* have a banner nowadays).
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 So the first thing that you need to do is to go to the http://patorjk.com/software/taag[following website] and pick up your favorite "Villain API" text banner.
 
@@ -76,14 +77,17 @@ public class VillainApplicationLifeCycle {
     }
 }
 ----
+--
 
 Thanks to the CDI `@Observes`, the `VillainApplicationLifeCycle` is invoked.
 On startup with the `StartupEvent` so it can execute code (here, displaying the banner) when the application is starting
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Run the application with: `./mvnw quarkus:dev`, the banner is printed to the console.
 When the application is stopped, the second log message is printed.
+--
 
 [NOTE]
 ====
@@ -94,10 +98,11 @@ The method is called by ArC, the dependency injection framework used by Quarkus.
 Arc embraces the build-time principle, meaning that injection happens at build time.
 In addition, Arc can detect and remove unused beans at runtime, saving memory.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 With the application running in dev mode, open your browser to http://localhost:8084/q/dev/.
 In the ArC widget, you can see the number of beans that have been removed ("Removed Beans"), and if you click on the link, see the list.
 If you click on the "Observers" link, you will see the two methods we added.
 In the "Fired Events" view, you can see which event has been fired and when.
-
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-native.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-native.adoc
@@ -35,11 +35,12 @@ To do so, you will find in the `pom.xml` the following profile:
 
 Make sure you have the `GRAALVM_HOME` environment variable defined and pointing to where you installed GraalVM.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Then create a native executable using: `./mvnw package -Pnative`.
 In addition to the regular files, the build also produces `target/rest-villains-1.0.0-SNAPSHOT-runner` (notice that there is no `.jar` file extension).
 You can run it using `./target/rest-villains-1.0.0-SNAPSHOT-runner` and curl the endpoint with `curl http://localhost:8084/api/villains`.
+--
 
 [WARNING]
 ====

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-profile.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/2-quarkus/quarkus-profile.adoc
@@ -12,7 +12,8 @@ Quarkus has three profiles by default, although it is possible to use as many as
 
 Let's change the `VillainApplicationLifeCycle` so it displays the current profile.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For that, just add a log invoking `ProfileManager.getActiveProfile()` in the `onStart()` method:
 
@@ -20,6 +21,7 @@ For that, just add a log invoking `ProfileManager.getActiveProfile()` in the `on
 ----
 LOGGER.info("The application VILLAIN is starting with profile " + ProfileManager.getActiveProfile());
 ----
+--
 
 [NOTE]
 --

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/3-reactive/reactive.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/3-reactive/reactive.adoc
@@ -43,7 +43,8 @@ New microservice, new project!
 The easiest way to create this new Quarkus project is to use the Quarkus Maven plugin.
 Open a terminal and run the following command:
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 [source,shell,subs="attributes+"]
 ----
@@ -56,6 +57,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dpath="api/heroes" \
     -Dextensions="resteasy-reactive-jackson,quarkus-hibernate-validator,quarkus-smallrye-openapi,quarkus-hibernate-reactive-panache,quarkus-reactive-pg-client"
 ----
+--
 
 As you can see, we can select multiple extensions during the project creation:
 
@@ -122,7 +124,8 @@ super-heroes
 
 Let's start with the `Hero` entity class.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the `io.quarkus.workshop.superheroes.hero.Hero` class in the created project with the following content:
 
@@ -177,6 +180,7 @@ public class Hero extends PanacheEntity {
     }
 }
 ----
+--
 
 First, note that we are extending `io.quarkus.hibernate.reactive.panache.PanacheEntity`.
 It's the reactive variant of `import io.quarkus.hibernate.orm.panache.PanacheEntity`.
@@ -220,8 +224,8 @@ However, most of the time, Quarkus handles the subscription for us.
 Unlike the `VillainResource`, the `HeroResource` uses the reactive development model.
 It returns asynchronous structures (`Uni`)footnote:[There is another structure `Multi` to represent asynchronous streams of items. We will see `Multi` examples later].
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Open the `HeroResource` and update the content to be:
 
 [source,java]
@@ -350,6 +354,7 @@ public class HeroResource {
     }
 }
 ----
+--
 
 The resource implements the same HTTP API as the villain counterpart.
 It does not use a transactional service, but uses Panache method directly.
@@ -364,8 +369,8 @@ Notice also the `@ReactiveTransactional`, which is the reactive variant of `@Tra
 
 Configuring the reactive access to the database is relatively similar to configuring the JDBC url.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Open the `application.properties` file and add:
 
 [source,properties]
@@ -381,6 +386,7 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 %prod.quarkus.datasource.reactive.url=postgresql://localhost:5432/heroes_database
 %prod.quarkus.hibernate-orm.sql-load-script=import.sql
 ----
+--
 
 The _prod_ profile contains the `%prod.quarkus.datasource.reactive.url` which configure the access to the database.
 
@@ -388,7 +394,8 @@ We also set the port to be 8083.
 
 === Importing heroes
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the `src/main/resources/import.sql` and copy the content from {github-raw}/super-heroes/rest-heroes/src/main/resources/import.sql[import.sql].
 
@@ -408,13 +415,15 @@ VALUES (nextval('hero_seq'), 'Bill Harken', '', 'https://www.superherodb.com/pic
         'Super Speed, Super Strength, Toxin and Disease Resistance', 6);
 ...
 ----
+--
 
 === Testing the heroes
 
 Time for some tests!
 Open the `io.quarkus.workshop.superheroes.hero.HeroResourceTest` class and copy the following content:
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 [source,java]
 ----
@@ -627,18 +636,21 @@ public class HeroResourceTest {
     }
 }
 ----
+--
 
 The tests are very similar to the ones from the villain service.
 
 == Running, Testing and Packaging the Application
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 First, make sure the tests pass by executing the command `./mvnw test` (or from your IDE).
+--
 
 Now that the tests are green, we are ready to run our application.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Use `./mvnw quarkus:dev` to start it.
 Once the application is started, create a new hero with the following cUrl command:
@@ -650,6 +662,7 @@ curl -X POST -d  '{"level":2, "name":"Super level", "powers":"leaping"}'  -H "Co
 < HTTP/1.1 201 Created
 < Location: http://localhost:8083/api/heroes/952
 ----
+--
 
 The cUrl command returns the location of the newly created hero.
 Take this URL and do an HTTP GET on it.
@@ -670,9 +683,10 @@ curl http://localhost:8083/api/heroes/952 | jq
 
 Remember that you can also check Swagger UI by going to the dev console: http://localhost:8083/q/dev.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Then, build the application using: `./mvnw package`, and run the application using `java -jar target/quarkus-app/quarkus-run.jar`.
 Open your browser and go to http://localhost:8083/api/heroes.
-
+--
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-cors.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-cors.adoc
@@ -39,13 +39,15 @@ If the filter is enabled and an HTTP request is identified as cross-origin, the 
 |The duration indicating how long the results of a pre-flight request can be cached. This value will be returned in a Access-Control-Max-Age response header.
 |===
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 So make sure you set `quarkus.http.cors=true` and `%dev.quarkus.http.cors.origins=/.*/` properties on the:
 
 1. Fight microservice,
 2. Hero microservice,
 3. Villain microservice
+--
 
 But, even with this, the UI is still not working.
 The CORS errors are gone, so that's a good step, but we forgot something else:

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-fight.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-fight.adoc
@@ -14,7 +14,8 @@ IMPORTANT: This microservice uses the imperative development model but use react
 Like for the Hero and Villain API, the easiest way to create this new Quarkus project is to use a Maven archetype.
 Under the `quarkus-workshop-super-heroes/super-heroes` root directory where you have all your code.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Open a terminal and run the following command:
 
@@ -36,12 +37,13 @@ If you open the `pom.xml` file, you will see that the following extensions have 
 * `io.quarkus:quarkus-smallrye-reactive-messaging-kafka`
 * `io.quarkus:quarkus-resteasy-reactive-jackson`
 * `io.quarkus:quarkus-jdbc-postgresql`
+--
 
 You can see that beyond the extensions we have used so far, we added the Kafka support which uses Eclipse MicroProfile Reactive Messaging.
 Stay tuned.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 The Quarkus Maven plugin has generated some code that we won't be using.
 You can delete the Java classes `MyReactiveMessagingApplication` and `MyReactiveMessagingApplicationTest`.
 
@@ -51,6 +53,7 @@ If you want your IDE to manage this new Maven project, you can declare it in the
 ----
 <module>super-heroes/rest-fights</module>
 ----
+--
 
 == Directory Structure
 
@@ -109,7 +112,8 @@ A fight is between a hero and a villain.
 Each time there is a fight, there is a winner and a loser.
 So the `Fight` entity is there to store all these fights.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the `io.quarkus.workshop.superheroes.fight.Fight` class with the following content:
 
@@ -149,6 +153,7 @@ public class Fight extends PanacheEntity {
 
 }
 ----
+--
 
 == Fighters Bean
 
@@ -157,7 +162,8 @@ The Fight REST API will ultimately invoke the Hero and Villain APIs (next sectio
 The `Fighters` class has one `Hero` and one `Villain`.
 Notice that `Fighters` is not an entity, it is not persisted in the database, just marshalled and unmarshalled to JSon.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the `io.quarkus.workshop.superheroes.fight.Fighters` class, with the following content:
 
@@ -181,12 +187,13 @@ public class Fighters {
 
 }
 ----
+--
 
 It does not compile because it needs a `Hero`  class and a `Villain` class.
 The Fight REST API is just interested in the hero's name, level, picture and powers (not the other name as described in the Hero API).
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 So create the `Hero` bean looks like this (notice the `client` subpackage):
 
 [source]
@@ -234,6 +241,7 @@ public class Villain {
 
 }
 ----
+--
 
 So, these classes are just used to map the results from the `Hero` and `Villain` microservices.
 
@@ -241,7 +249,8 @@ So, these classes are just used to map the results from the `Hero` and `Villain`
 
 Now, let's create a `FightService` class that orchestrate the fights.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the `io.quarkus.workshop.superheroes.fight.FightService` class with the following content:
 
@@ -341,6 +350,7 @@ Notice the `persistFight` method.
 This method is the one creating a fight between a hero and a villain.
 As you can see the algorithm to determine the winner is a bit random (even though it uses the levels).
 If you are not happy about the way the fight operates, choose your own winning algorithm ;o)
+--
 
 [NOTE]
 ====
@@ -352,7 +362,8 @@ Later, this method will invoke the Hello and Villain API to get a random Hero an
 
 To expose a REST API we also need a `FightResource` (with OpenAPI annotations of course).
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 [source,java]
 ----
@@ -422,13 +433,15 @@ public class FightResource {
     }
 }
 ----
-
+--
+s
 NOTE: The OpenAPI annotations have been omitted to keep the service focused on the task.
 Feel free to add them if you want complete OpenAPI descriptors.
 
 == Adding Data
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 To load some SQL statements when Hibernate ORM starts, create the `src/main/resources/import.sql` file with the following content:
 
@@ -452,12 +465,14 @@ VALUES (nextval('fight_seq'), current_timestamp, 'Annihilus', 23,
         'https://www.superherodb.com/pictures2/portraits/10/050/1307.jpg', 'Shikamaru', 1,
         'https://www.superherodb.com/pictures2/portraits/10/050/11742.jpg', 'villains', 'heroes');
 ----
+--
 
 == Configuration
 
 As usual, we need to configure the application.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 In the `application.properties` file add:
 
@@ -484,6 +499,7 @@ quarkus.log.console.level=DEBUG
 %prod.quarkus.log.console.level=INFO
 %prod.quarkus.hibernate-orm.database.generation=update
 ----
+--
 
 Note that the fight service uses the port `8082`.
 
@@ -491,7 +507,8 @@ Note that the fight service uses the port `8082`.
 
 We need to test our REST API.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For that, copy the following `FightResourceTest` class under the `src/test/java/io/quarkus/workshop/superheroes/fight` directory.
 
@@ -644,10 +661,12 @@ public class FightResourceTest {
     }
 }
 ----
+--
 
 == Running, Testing and Packaging the Application
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 First, delete the generated `FightResourceIT` native test class, as we won't run native tests.
 Then, make sure the tests pass by executing the command `./mvnw test` (or from your IDE).
@@ -663,3 +682,4 @@ curl http://localhost:8082/api/fights
 ----
 
 Remember that you can also check Swagger UI by going to http://localhost:8082/q/swagger-ui.
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-ui.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/4-microservices/microservices-ui.adoc
@@ -32,12 +32,13 @@ All the Angular code (graphical components, model, services) is located under `s
 
 We don't need to worry too much about the Angular code.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 From the `ui-super-heroes`
 directory, use `./mvnw quarkus:dev` to start the web application.
 
 Be sure you have the hero, villain and fights microservices running (dev mode is enough).
+--
 
 If you don't have Node installed, Quinoa will install it during the start process.
 
@@ -76,20 +77,22 @@ However, that's beyond the scope of this workshop!
 
 Live coding works for the javascript parts of the application, just as it does for the Java ones.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Open `src/main/webui/src/app/app.component.html` and edit the text, perhaps by adding 'Hello there' into the welcome message.
 Check localhost:8080, and your new content should appear.
 (It may take a moment or two for the refresh to trigger.)
 
 You can also change the javascript code.
 For example, try updating the text in `src/main/webui/src/app/app.component.ts`.
+--
 
 == Native compilation and Quinoa
 
 You can compile the UI application as a native binary, just like other Quarkus applications.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Try compiling natively with
 
@@ -100,3 +103,4 @@ Try compiling natively with
 
 The native compilation will take a while, but once it's done, the UI will start in around 0.02s.
 You can confirm it's working by checking http://localhost:8080.
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/fallbacks.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/fallbacks.adoc
@@ -31,12 +31,14 @@ To simplify making more resilient applications, Quarkus contains an implementati
 
 To install the MicroProfile Fault Tolerance dependency, just run the following command in the Fight microservice:
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 [source,shell]
 ----
 ./mvnw quarkus:add-extension -Dextensions="smallrye-fault-tolerance"
 ----
+--
 
 This will add the following dependency in the `pom.xml` file:
 
@@ -52,7 +54,8 @@ This will add the following dependency in the `pom.xml` file:
 
 Let's make our find random fighters feature better by providing a fallback way of getting a dummy hero or villain in case of failure.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For that, add two fallback methods to the `FightService` and a `@Fallback` annotation to both `findRandomHero` and `findRandomVillain` methods as follows:
 
@@ -89,6 +92,7 @@ public Villain fallbackRandomVillain() {
     return villain;
 }
 ----
+--
 
 [NOTE]
 --
@@ -99,8 +103,8 @@ Also add the `import org.eclipse.microprofile.faulttolerance.Fallback;` statemen
 
 Now we are ready to run our application and test the fallbacks.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 For that, kill the Hero (and/or the Villain API) and start playing again.
 You should see the following:
 
@@ -108,3 +112,4 @@ image::fault-tolerance-fallback.png[role=half-size]
 
 Restart the Hero REST API... and keep on playing.
 Super-heroes are back to the fight!
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/rest-clients.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/rest-clients.adoc
@@ -65,7 +65,8 @@ We are going to rework the:
 
 == Installing the Reactive REST Client Dependency
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 To install the Reactive REST Client dependency, just run the following command in the Fight microservice:
 
@@ -73,6 +74,7 @@ To install the Reactive REST Client dependency, just run the following command i
 ----
 ./mvnw quarkus:add-extension -Dextensions="io.quarkus:quarkus-rest-client-reactive-jackson"
 ----
+--
 
 This will add the following dependency in the `pom.xml` file:
 
@@ -92,8 +94,8 @@ Remember that in the previous sections we left the `FightService.findRandomFight
 We have to fix this.
 What we actually want is to invoke both the Hero and Villain APIs, asking for a random hero and a random villain.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 For that, replace the `findRandomFighters` method with the following code to the `FightService` class:
 
 [source,java,indent=0]
@@ -126,6 +128,7 @@ Hero findRandomHero() {
 Note the Rest client injection.
 They use the `@RestClient` qualifier, i.e. a bean selector.
 With Quarkus, when you use a qualifier, you can omit `@Inject`.
+--
 
 [NOTE]
 --
@@ -136,7 +139,8 @@ If not done automatically by your IDE, add the following import statement: `impo
 
 Using the MicroProfile REST Client is as simple as creating an interface using the proper JAX-RS and MicroProfile annotations.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 In our case both interfaces should be created under the `client` subpackage and have the following content:
 
@@ -164,6 +168,7 @@ public interface HeroProxy {
 
 The `findRandomHero` method gives our code the ability to query a random hero from the Hero REST API.
 The client will handle all the networking and marshalling leaving our code clean of such technical details.
+--
 
 The purpose of the annotations in the code above is the following:
 
@@ -195,19 +200,22 @@ public interface VillainProxy {
 }
 ----
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Once created, go back to the `FightService` class and add the following import statements:
 
 [source]
---
+----
 import io.quarkus.workshop.superheroes.fight.client.HeroProxy;
 import io.quarkus.workshop.superheroes.fight.client.VillainProxy;
+----
 --
 
 == Configuring REST Client Invocation
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 In order to determine the base URL to which REST calls will be made, the REST Client uses configuration from `application.properties`.
 The name of the property needs to follow a certain convention which is best displayed in the following code:
@@ -219,6 +227,7 @@ io.quarkus.workshop.superheroes.fight.client.HeroProxy/mp-rest/scope=jakarta.inj
 io.quarkus.workshop.superheroes.fight.client.VillainProxy/mp-rest/url=http://localhost:8084
 io.quarkus.workshop.superheroes.fight.client.VillainProxy/mp-rest/scope=jakarta.inject.Singleton
 ----
+--
 
 Having this configuration means that all requests performed using `HeroProxy` will use http://localhost:8083 as the base URL.
 Using this configuration, calling the `findRandomHero` method of `HeroProxy` would result in an HTTP GET request being made to http://localhost:8083/api/heroes/random.
@@ -238,11 +247,13 @@ To avoid this, we need to Mock the `HeroProxy` and `VillainProxy` interfaces.
 
 Quarkus supports the use of mock objects using the CDI `@Alternative` mechanism.footnote:[Alternatives https://docs.jboss.org/weld/reference/latest/en-US/html/specialization.html#_using_alternative_stereotypes]
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 To use this simply override the bean you wish to mock with a class in the `src/test/java` directory, and put the `@Alternative` and `@Priority(1)` annotations on the bean.
 Alternatively, a convenient `io.quarkus.test.Mock` stereotype annotation could be used.
 This built-in stereotype declares `@Alternative`, `@Priority(1)` and `@Dependent`.
+
 
 === Mocking a Villain service
 
@@ -264,6 +275,7 @@ manually, and then fill in the following contents:
 ----
 include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/DefaultTestVillain.java[]
 ----
+--
 
 === Mocking a Hero service
 
@@ -313,8 +325,8 @@ The `when` call is a static import of `Mockito.when`. The
 https://quarkus.io/guides/getting-started-testing#further-simplification-with-injectmock[`@InjectMock`] annotation results in a mock being created and made available in test methods of the test class.
 Importantly, other test classes are not affected by this.
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Finally, edit the `FightResourceTest` and add the following method:
 
 [source,java]
@@ -326,3 +338,4 @@ Now, run the test from the dev mode, or from your IDE.
 You can shutdown the hero and villain services to verify that the tests still pass.
 
 Don't forget to restart them before going further.
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/timeout.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5-rest-client/timeout.adoc
@@ -13,8 +13,8 @@ image::fault-tolerance-pending.png[role=half-size]
 
 Getting random fighters can take longer than expected.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 To simulate a long-running process, add the following code to the `FightResource`:
 
 [source,java,indent=0]
@@ -40,6 +40,7 @@ public Response getRandomFighters() {
     return Response.ok(fighters).build();
 }
 ----
+--
 
 [NOTE]
 --
@@ -49,8 +50,8 @@ Don't forget to add the following import: `import org.eclipse.microprofile.confi
 Let's say we've added some new functionality in the `veryLongProcess` method.
 When the process is really too long and the system is overloaded, we would rather time out.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Note that the timeout was configured to 500 ms, and a `Thread.sleep` was introduced and can be configured in the `application.properties`.
 If we set the property to a higher value than the timeout, let's say 10.000, then the request should be interrupted.
 
@@ -58,6 +59,7 @@ If we set the property to a higher value than the timeout, let's say 10.000, the
 ----
 process.milliseconds=10000
 ----
+--
 
 == Running the Application
 
@@ -73,8 +75,11 @@ You should see the following:
 ...
 ----
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Before going further, set the `process.milliseconds` to 0.
+--
 
 include::../common-solution.adoc[]
+

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/happy-path-consumer-tests.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/happy-path-consumer-tests.adoc
@@ -6,7 +6,8 @@ which means that we begin by writing tests for the API consumer.
 
 == Writing the first contract test
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Add the Pact Quarkus extension to the `pom.xml` of the Fights service:
 
@@ -19,7 +20,7 @@ Add the Pact Quarkus extension to the `pom.xml` of the Fights service:
             <scope>test</scope>
         </dependency>
 ----
-
+--
 
 The Pact framework will stand up a server which listens on a port.
 To avoid port conflicts between the real services and the Pact stubs, let's use a different port for the contract instances.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/pact.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/pact.adoc
@@ -20,7 +20,8 @@ However, the fields in the two classes should be roughly the same.
 
 What happens if we do some refactoring?
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 In the `rest-heroes` project, let's do some searching and replacing.
 (We do search and replace so we catch both Java and SQL in our refactoring.)
@@ -31,6 +32,7 @@ Make sure to only do search within the rest-heroes directory.
 Check all of your tests.
 The heroes, villains, and fights tests should all be running clean.
 A successful refactoring!
+--
 
 Now visit the UI at http://localhost:4200/.
 What's going on?

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/provider-tests.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/provider-tests.adoc
@@ -37,7 +37,8 @@ The Pact framework will generate a test for each expectation in the contract and
 
 (No need to put that snippet anywhere yet, we will see how it fits into a test class in a moment.)
 
-icon:hand-point-right[role="red",size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Add the Pact dependency to the heroes service `pom.xml`:
 
@@ -88,3 +89,4 @@ public class HeroContractVerificationTest {
 ----
 
 When you run the tests they should pass.
+--

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/6-messaging/messaging-receiving-from-kafka.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/6-messaging/messaging-receiving-from-kafka.adoc
@@ -42,7 +42,8 @@ super-heroes
 Like for the other microservice, the easiest way to create this new Quarkus project is to use a Maven command.
 Under the `quarkus-workshop-super-heroes/super-heroes` root directory where you have all your code.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Open a terminal and run the following command:
 
@@ -55,6 +56,7 @@ mvn io.quarkus:quarkus-maven-plugin:{quarkus-version}:create \
     -Dpath="api/stats" \
     -Dextensions="kafka, resteasy-reactive-jackson, websockets"
 ----
+--
 
 If you want your IDE to manage this new Maven project, you can declare it in the parent POM by adding this new module in the `<modules>` section:
 
@@ -63,14 +65,17 @@ If you want your IDE to manage this new Maven project, you can declare it in the
 <module>super-heroes/event-statistics</module>
 ----
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Delete all the classes under the `io.quarkus.workshop.superheroes.statistics` package as well as the associated test classes.
 There are just examples.
+--
 
 == Consuming Fight
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 This service receives the `Fight` from the fight microservice.
 So, naturally, we need a fight class.
@@ -114,11 +119,12 @@ public class FightDeserializer extends ObjectMapperDeserializer<Fight> {
     }
 }
 ----
+--
 
 == Computing Statistics
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Now, create the `io.quarkus.workshop.superheroes.statistics.SuperStats` class with the following content.
 This class contains two methods annotated with `@Incoming` and `@Outgoing`, both consuming the `Fight` coming from Kafka.
 
@@ -177,8 +183,10 @@ public class SuperStats {
 
 }
 ----
+--
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 In addition, create the `io.quarkus.workshop.superheroes.statistics.Ranking`, `io.quarkus.workshop.superheroes.statistics.Score` and `io.quarkus.workshop.superheroes.statistics.TeamStats` classes with the following contents:
 
@@ -222,7 +230,7 @@ public class Ranking {
     }
 }
 ----
-
+--
 The `Score` class is a simple structure storing the name of a hero or villain and its actual score, _i.e._ the number of won battles.
 
 [source,java]
@@ -275,8 +283,8 @@ Without, the serialization/deserialization would not work when running the nativ
 
 It's now time to connect the `fights` channel with the Kafka topic.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Edit the `application.properties` file and add the following content:
 
 [source,properties]
@@ -288,6 +296,7 @@ mp.messaging.incoming.fights.connector=smallrye-kafka
 mp.messaging.incoming.fights.auto.offset.reset=earliest
 mp.messaging.incoming.fights.broadcast=true
 ----
+--
 
 As for the writing side, it configures the Kafka connector.
 The `mp.messaging.incoming.fights.auto.offset.reset=earliest` property indicates that the topic is read from the earliest available record.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/6-messaging/messaging-sending-to-kafka.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/6-messaging/messaging-sending-to-kafka.adoc
@@ -42,7 +42,8 @@ super-heroes
 
 == Adding the Reactive Messaging Dependency
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 The Kafka extension was already imported during the project creation.
 In doubt, you can run in the Fight microservice:
@@ -51,6 +52,7 @@ In doubt, you can run in the Fight microservice:
 ----
 ./mvnw quarkus:add-extension -Dextensions=" io.quarkus:quarkus-smallrye-reactive-messaging-kafka"
 ----
+--
 
 The previous command adds the following dependency:
 
@@ -73,7 +75,8 @@ Quarkus starts a Kafka broker automatically.
 
 == Connecting Imperative and Reactive Using an Emitter
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Now edit the `FightService` class.
 First, add the following field:
@@ -82,6 +85,7 @@ First, add the following field:
 ----
 @Channel("fights") Emitter<Fight> emitter;
 ----
+--
 
 [NOTE]
 ====
@@ -112,8 +116,8 @@ Thus, we wait until Kafka confirms the reception before returning.
 At this point, the serialized fights are sent to the `fights` channel.
 You need to connect this `channel` to a Kafka topic.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 For this, edit the `application.properties` file and add the following properties:
 
 [source,properties]
@@ -121,6 +125,7 @@ For this, edit the `application.properties` file and add the following propertie
 mp.messaging.outgoing.fights.connector=smallrye-kafka
 mp.messaging.outgoing.fights.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
 ----
+--
 
 These properties are structured as follows:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/6-messaging/messaging-websocket.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/6-messaging/messaging-websocket.adoc
@@ -14,7 +14,8 @@ Quarkus uses the http://jcp.org/en/jsr/detail?id=356[JSR 356] providing an annot
 
 == The TeamStats WebSocket
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the `io.quarkus.workshop.superheroes.statistics.TeamStatsWebSocket` class with the following content:
 
@@ -80,6 +81,7 @@ public class TeamStatsWebSocket {
     }
 }
 ----
+--
 
 This component is a WebSocket as specified by the `@ServerEndpoint("/stats/team")` annotation.
 It handles the `/stats/team` WebSocket.
@@ -99,9 +101,10 @@ Without it, items would not be emitted.
 
 The `io.quarkus.workshop.superheroes.statistics.TopWinnerWebSocket` follows the same pattern but subscribes to the `winner-stats` channel.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
-Creates the `io.quarkus.workshop.superheroes.statistics.TopWinnerWebSocket` with the following content:
+Create the `io.quarkus.workshop.superheroes.statistics.TopWinnerWebSocket` with the following content:
 
 [source,java]
 ----
@@ -170,6 +173,7 @@ public class TopWinnerWebSocket {
     }
 }
 ----
+--
 
 Because the items (top 10) need to be serialized, the `TopWinnerWebSocket` also use Jackson to transform the object into a serialized form.
 
@@ -177,8 +181,8 @@ Because the items (top 10) need to be serialized, the `TopWinnerWebSocket` also 
 
 Finally, you need a UI to watch these live statistics.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 
 Replace the `META-INF/resources/index.html` file with the following content:
 
@@ -290,12 +294,14 @@ Replace the `META-INF/resources/index.html` file with the following content:
 </body>
 </html>
 ----
+--
 
 == Running the Application
 
 You are all set!
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Time to start the application using:
 
@@ -306,6 +312,7 @@ Time to start the application using:
 
 Then, open `http://localhost:8085` in a new browser window.
 Trigger some fights, and you should see the live statistics moving.
+--
 
 Quarkus automatically reuse the Kafka broker from the fight service.
 So, make sure the fight service is started.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-healthcheck.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-healthcheck.adoc
@@ -45,14 +45,15 @@ You can apply the same to the other microservices.
 
 == Installing the Health Dependency
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 To install the MicroProfile Health dependency, just run the following command under the Hero microservice directory (`super-heroes/rest-heroes`):
 
 [source,shell]
 ----
 ./mvnw quarkus:add-extension -Dextensions="smallrye-health"
 ----
+--
 
 This will add the following dependency in the `pom.xml` file:
 
@@ -111,8 +112,8 @@ But let's define some specific to our microservices.
 
 To check that our Hero API application is live, we can check that the `HeroResource.hello()` method works.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 For that, this is the `PingHeroResourceHealthCheck` class that we can write under the `io.quarkus.workshop.superheroes.hero.health` sub-package:
 
 [source,java]
@@ -139,13 +140,14 @@ public class PingHeroResourceHealthCheck implements HealthCheck {
     }
 }
 ----
+--
 
 As you can see health check procedures are defined as implementations of the `HealthCheck` interface which are defined as CDI beans with the CDI qualifier `@Liveness`.
 The liveness check accessible at `/q/health/live`.
 `HealthCheck` is a functional interface whose single method `call` returns a `HealthCheckResponse` object which can be easily constructed by the fluent builder API shown in the example.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 As we have started our Quarkus application in dev mode simply repeat the request to http://localhost:8083/q/health/live by refreshing your browser window or by using curl http://localhost:8083/q/health/live.
 Because we defined our health check to be a liveness procedure (with `@Liveness` qualifier) the new health check procedure is now present in the checks array.
 
@@ -165,6 +167,7 @@ Because we defined our health check to be a liveness procedure (with `@Liveness`
     ]
 }
 ----
+--
 
 //== Adding Readiness
 //
@@ -174,7 +177,6 @@ Because we defined our health check to be a liveness procedure (with `@Liveness`
 //We will create another health check procedure that accesses our database.
 //If the database can be accessed, then we will always return the response indicating the application is ready.
 //
-//icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 //
 //Create the `io.quarkus.workshop.superheroes.hero.health.DatabaseConnectionHealthCheck` class as follow:
 //
@@ -209,7 +211,6 @@ Because we defined our health check to be a liveness procedure (with `@Liveness`
 //
 //== Health Check Tests in HeroResourceTest
 //
-//icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 //
 //Let's add a few extra test methods that would make sure Health Check are available in the application:
 //

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-load.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-load.adoc
@@ -22,8 +22,8 @@ include::{github-raw}/super-heroes/load-super-heroes/src/main/java/io/quarkus/wo
 
 == Running the Load Application
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 You are all set!
 Time to compile and start the load application using:
 
@@ -32,6 +32,7 @@ Time to compile and start the load application using:
 mvn compile
 mvn exec:java
 ----
+--
 
 You will see the following logs:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-metrics.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-metrics.adoc
@@ -9,7 +9,8 @@ You can apply the same to the other microservices.
 
 == Installing the Metrics Dependency
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 To install the MicroProfile Metrics dependency, just run the following command:
 
@@ -17,6 +18,7 @@ To install the MicroProfile Metrics dependency, just run the following command:
 ----
 ./mvnw quarkus:add-extension -Dextensions="metrics"
 ----
+--
 
 This will add the following dependency in the `pom.xml` file:
 
@@ -29,13 +31,15 @@ include::{github-raw}/super-heroes/rest-hero/pom.xml[tags=adocDependencyMetrics]
 
 We want now to measure all methods of all our REST resources.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For that, we need a few annotations to make sure that our desired metrics are calculated over time and can be exported for manual analysis or processing by additional tooling.
 The metrics that we will gather are these:
 
 * `countGetRandomHero`: A counter which is increased by one each time the user gets a random hero.
 * `timeGetRandomHero`: This is a timer, therefore a compound metric that benchmarks how much time the request take.
+--
 
 Below the source code of the `getRandomHero()` method, but make sure to add metrics on all methods:
 
@@ -43,8 +47,9 @@ Below the source code of the `getRandomHero()` method, but make sure to add metr
 ----
 include::{github-raw}/super-heroes/rest-hero/src/main/java/io/quarkus/workshop/superheroes/hero/HeroResource.java[tags=adocMetricsMethods]
 ----
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
 
+[example, role="cta"]
+--
 [NOTE]
 --
 You will need to add the following import statements:
@@ -54,10 +59,12 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 ```
 --
+--
 
 == Metrics Tests in HeroResourceTest
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Let's add an extra test method that would make sure Metrics are available in the application:
 
@@ -94,6 +101,7 @@ You will receive a response such as:
   }
 }
 ----
+--
 
 Let’s explain the meaning of each metric:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-prometheus.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/7-observability/observability-prometheus.adoc
@@ -42,8 +42,8 @@ image::fault-tolerance-prometheus-1.png[role=half-size]
 Out of the box, you get a lot of basic JVM metrics or even metrics of Prometheus itself, which are useful.
 But let's create new graphs with the metrics of our microservices.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Tape `timeGetRandomHero` in the query, and select `application_io_quarkus_workshop_superheroes_hero_HeroResource_timeGetRandomHero_five_min_rate_per_second` in the box, and click _Execute_.
 
 image::fault-tolerance-prometheus-2.png[role=half-size]
@@ -51,6 +51,7 @@ image::fault-tolerance-prometheus-2.png[role=half-size]
 This will fetch the values from our metric showing the number of checks performed:
 
 image::fault-tolerance-prometheus-3.png[role=half-size]
+--
 
 include::common-solution.adoc[]
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/8-quarkus-extension/extension.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/8-quarkus-extension/extension.adoc
@@ -49,7 +49,8 @@ As stated above, an extension is divided into two parts, called `deployment` (au
 include::{plantDir}/8-extension-architecture.puml[]
 ----
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 From the directory `super-heroes` execute the following commands:
 
@@ -61,6 +62,7 @@ mvn io.quarkus.platform:quarkus-maven-plugin:{quarkus-version}:create-extension 
     -DgroupId=io.quarkus.workshop.super-heroes \
     -DpackageName=io.quarkus.workshop.superheroes.version
 ----
+--
 
 This command creates the structure for the version extension:
 
@@ -132,7 +134,8 @@ For this, what do we need:
 The _runtime_ part of an extension contains only the classes and resources required at runtime.
 For the version extension, it would be a single class that prints the version.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 In the runtime module, create the `src/main/java` directory, and, in this directory, the `io.quarkus.workshop.superheroes.version.runtime.VersionRecorder` class with the following content:
 
@@ -140,6 +143,7 @@ In the runtime module, create the `src/main/java` directory, and, in this direct
 ----
 include::{code-root}/extension-version/runtime/src/main/java/io/quarkus/workshop/superheroes/version/runtime/VersionRecorder.java[]
 ----
+--
 
 Simple right?
 But how does it work?
@@ -153,8 +157,8 @@ We will see how this recorder is used from the _deployment_ module.
 This module contains _build steps_, i.e., methods called during the augmentation phase and computing just enough bytecode to serve the services the application requires.
 The version extension consists of a single build step that extracts the version and uses the `VersionRecorder`.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 First, let's create the configuration class that will allow users to dynamically configure whether the version should be printed:
 
 Under the `deployment` module, create new class `io.quarkus.workshop.superheroes.version.deployment.VersionConfig` with the following content:
@@ -163,6 +167,7 @@ Under the `deployment` module, create new class `io.quarkus.workshop.superheroes
 ----
 include::{code-root}/extension-version/deployment/src/main/java/io/quarkus/workshop/superheroes/version/deployment/VersionConfig.java[]
 ----
+--
 
 The `@ConfigRoot` annotation declares `VersionConfig` as a configuration class which configuration properties are prefixed with `quarkus.` prefix.
 
@@ -204,7 +209,8 @@ Any invocations made on these proxies will be recorded, and bytecode will be wri
 
 == Packaging the extension
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 From the root directory of the extension, run:
 
@@ -212,10 +218,12 @@ From the root directory of the extension, run:
 ----
 mvn clean install
 ----
+--
 
 == Using the extension
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Go back to the _villain_ microservice, and add the following dependency to the `pom.xml` file:
 
@@ -230,6 +238,7 @@ If not yet started, start the microservice with:
 ----
 ./mvnw quarkus:dev
 ----
+--
 
 And the version will be displayed:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/9-kubernetes/cloud.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/9-kubernetes/cloud.adoc
@@ -34,7 +34,8 @@ So, first, be sure that your container system has enough memory to build the exe
 It requires at least 6Gb of memory, 8Gb is recommended.
 ====
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Execute the above command for all our microservices.
 We also copy the UI into the fight service, to simplify the process:
@@ -55,6 +56,7 @@ cd event-statistics
 mvn clean package -Pnative -Dquarkus.native.container-build=true -DskipTests
 cd ..
 ----
+--
 
 == Building containers
 
@@ -132,7 +134,8 @@ Here, we are going to use two operators:
 * PostgreSQL Operator by Dev4Ddevs.com
 * Strimzi Apache Kafka Operator by Red Hat
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 With these operators installed, you can create the required infrastructure with the following custom resource definition (CRD):
 
@@ -158,8 +161,10 @@ spec:
     image: centos/postgresql-96-centos7
     size: 1
 ----
+--
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 This CRD creates the database for the Hero microservice.
 Duplicate this CRD for the fight and villain databases.
@@ -195,12 +200,14 @@ spec:
     topicOperator: {}
     userOperator: {}
 ----
+--
 
 This CRD creates the brokers and the Zookeeper instances.
 
 It's also recommended to create the topic.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For this, create the following CRD:
 
@@ -243,7 +250,8 @@ Let's start with the hero and villain microservices.
 
 For each, we need to override the port and data source URL.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create a config map with the following content:
 
@@ -258,8 +266,10 @@ kind: ConfigMap
 metadata:
     name: hero-config
 ----
+--
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Do the same for the villain microservice.
 Then, apply these resources:
@@ -269,10 +279,12 @@ Then, apply these resources:
 $ kubectl apply -f config-hero.yaml
 $ kubectl apply -f config-villain.yaml
 ----
+--
 
 Once the config maps are created, we can deploy the microservices.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create a `deployment-hero.yaml` file with the following content:
 
@@ -350,6 +362,7 @@ items:
 
 
 ----
+--
 
 This descriptor declares:
 
@@ -359,8 +372,8 @@ This descriptor declares:
 The deployment declares one container using the container image we built earlier.
 It also overrides the configuration for the HTTP port and database URL.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Don't forget to create the equivalent files for the villain microservice.
 
 Then, deploy the microservice with:
@@ -370,6 +383,7 @@ Then, deploy the microservice with:
 $ kubectl apply -f deployment-hero.yaml
 $ kubectl apply -f deployment-villain.yaml
 ----
+--
 
 === Deploying the Fight microservice
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-aca-running-app.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-aca-running-app.adoc
@@ -12,8 +12,8 @@ Before deploying our microservices to Azure Container Apps, we need to create th
 
 === Create a Container Apps environment
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 First, let's create the container apps environment.
 A container apps environment acts as a boundary for our containers.
 Containers deployed on the same environment use the same virtual network and the same Log Analytics workspace.
@@ -23,10 +23,12 @@ Create the container apps environment with the following command:
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateACAEnv]
 ----
+--
 
 === Create the managed Postgres Databases
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 We need to create three PostgreSQL databases so the Heroes, Villains and Fights microservice can store data.
 Because we also want to access these database from external SQL client, we make them available to the outside world thanks to the `-public all` parameter.
@@ -46,8 +48,10 @@ include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=ad
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresF]
 ----
+--
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Then, we create the database schemas, one for each database:
 
@@ -65,8 +69,10 @@ include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=ad
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaF]
 ----
+--
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Now that we have all our databases setup, time to create the tables and add some data to them.
 Each microservice comes with a set of database initialization files as well as some insert statements.
@@ -77,6 +83,7 @@ Create the tables using the following commands (make sure you are under `quarkus
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableH]
 ----
+--
 
 [NOTE]
 ====
@@ -94,7 +101,8 @@ include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=ad
 include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableF]
 ----
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Now, let's add some super heroes and super villains to these databases:
 
@@ -130,13 +138,15 @@ include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=ad
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataF]
 ----
+--
 
 === Create the Managed Kafka
 
 The Fight microservice communicates with the Statistics microservice through Kafka.
 We need to create an Azure event hub for that.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 [source,shell,indent=0]
 ----
@@ -160,6 +170,7 @@ include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=ad
 If you log into the https://portal.azure.com[Azure Portal] you should see the following created resources.
 
 image::azure-portal-3.png[]
+--
 
 == Deploying the Applications
 
@@ -198,7 +209,8 @@ Therefore, we need to set the right properties using our environment variables.
 Notice that the Heroes microservice has a `--min-replicas` set to 0.
 That means it can scale down to zero if not used (more on that later).
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the Heroes container app with the following command:
 
@@ -206,6 +218,7 @@ Create the Heroes container app with the following command:
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppHero]
 ----
+
 
 The following command sets the URL of the deployed application to the `HEROES_URL` variable:
 
@@ -228,6 +241,7 @@ To access the logs of the Heroes microservice, you can write the following query
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppHeroLogs]
 ----
+--
 
 [WARNING]
 ====
@@ -239,7 +253,8 @@ Log analytics can take some time to get initialized.
 
 The Villain microservice also needs to access the managed Postgres database, so we need to set the right variables.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Notice the minimum of replicas is also set to 0:
 
@@ -269,12 +284,14 @@ To access the logs of the Villain microservice, you can write the following quer
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppVillainLogs]
 ----
+--
 
 === Statistics Microservice
 
 The Statistics microservice listens to a Kafka topics and consumes all the fights.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the Statistics container application with the following command:
 
@@ -303,6 +320,7 @@ To access the logs of the Statistics microservice, you can write the following q
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppStatisticsLogs]
 ----
+--
 
 === Fights Microservice
 
@@ -310,7 +328,8 @@ The Fight microservice invokes the Heroes and Villains microservices, sends figh
 We need to configure Kafka (same connection string as the one used by the Statistics microservice) as well as the Postgres database.
 As for the microservice invocations, you need to set the URLs of both Heroes and Villains microservices.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Create the Fights container application with the following command:
 
@@ -337,6 +356,7 @@ curl "$FIGHTS_URL/api/fights/hello"
 curl "$FIGHTS_URL/api/fights" | jq
 curl "$FIGHTS_URL/api/fights/randomfighters" | jq
 ----
+--
 
 To access the logs of the Fight microservice, you can write the following query:
 
@@ -351,7 +371,8 @@ Like for the previous microservices, we will be deploying the UI as Docker image
 But we could have also deployed the Super Hero UI using Azure Static Webapps which is suited for Angular applications.
 If you are interested in this approach, you can check https://azure.microsoft.com/services/app-service/static/[Azure Static Webapps].
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For now, let's continue with Azure Container Apps and deploy the UI as a Docker image with the following command:
 
@@ -369,6 +390,7 @@ include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocA
 ----
 open "$UI_URL"
 ----
+--
 
 To access the UI logs, you can write the following query:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-intro-preparing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-intro-preparing.adoc
@@ -7,14 +7,15 @@ Here are a few commands that you can execute before the workshop.
 
 == Clone the GitHub repository of the application
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 First, clone the GitHub repository of the Super Heroes application located at {github-url} by executing the following command:
 
 [source,shell,subs="attributes+"]
 ----
 git clone {github-repo}.git --depth 1
 ----
+--
 
 The code of this Super Heroes application is separated into two different directories:
 
@@ -64,7 +65,8 @@ include::../0-introduction/introduction-preparing-warming-docker.adoc[leveloffse
 To be able to deploy the application to Azure, you first need an Azure subscription.
 If you don't have one, go to https://signup.azure.com and register.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Then, sign in to Azure from the CLI:
 
@@ -79,12 +81,14 @@ Make sure you are using the right subscription with:
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocAzAccountShow]
 ----
+--
 
 === Setting Up the Azure Environment
 
 Azure CLI is extensible and you can install as many extensions as you need.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 For this workshop, install the Azure Container Apps and Database extensions for the Azure CLI:
 
@@ -134,6 +138,7 @@ az provider register --namespace Microsoft.App
 az provider register --namespace Microsoft.OperationalInsights
 az provider register --namespace Microsoft.Insights
 ----
+--
 
 == Creating Azure Resources
 
@@ -143,7 +148,8 @@ Before creating the infrastructure for the Super Heroes application and deployin
 
 Let's first set a few environment variables that will help us in creating the Azure infrastructure.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Set the following variables:
 
@@ -153,6 +159,7 @@ include::{github-raw}/super-heroes/infrastructure/azure-setup-env-var.sh[tags=ad
 ----
 
 Now let's create the Azure resources.
+--
 
 === Resource Group
 
@@ -160,7 +167,8 @@ A https://docs.microsoft.com/azure/azure-resource-manager/management/manage-reso
 The resource group can include all the resources for the solution, or only those resources that you want to manage as a group.
 In our workshop, all the databases, all the microservices, etc. will be grouped into a single resource group.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Execute the following command to create the Super Hero resource group:
 
@@ -168,6 +176,7 @@ Execute the following command to create the Super Hero resource group:
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocCreateResourceGroup]
 ----
+--
 
 === Log Analytics Workspace
 
@@ -175,8 +184,8 @@ https://docs.microsoft.com/azure/azure-monitor/logs/quick-create-workspace[Log A
 Each workspace has its own data repository and configuration, and data sources and solutions are configured to store their data in a particular workspace.
 We will use the same workspace for most of the Azure resources we will be creating.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Create a Log Analytics workspace with the following command:
 
 [source,shell,indent=0]
@@ -190,6 +199,7 @@ Let's also retrieve the Log Analytics Client ID and client secret and store them
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocLogAnalyticsSecrets]
 ----
+--
 
 === Azure Container Registry
 
@@ -197,7 +207,8 @@ In the next chapters we will be creating Docker containers and pushing them to t
 https://azure.microsoft.com/services/container-registry[Azure Container Registry] is a private registry for hosting container images.
 Using the Azure Container Registry, you can store Docker-formatted images for all types of container deployments.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 First, let's created an Azure Container Registry with the following command:
 
@@ -223,13 +234,15 @@ include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=
 If you log into the https://portal.azure.com[Azure Portal] you should see the following created resources.
 
 image::azure-portal-2.png[]
+--
 
 == Setting Up the Environment Variables
 
 The Super Heroes environment and application will be created and deployed using a set of Azure CLI commands.
 Each of these commands need a set of parameters, and some of these parameters can be set of environment variables.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 Set the following environment variables, there will be needed in the Azure CLI commands:
 
@@ -237,6 +250,7 @@ Set the following environment variables, there will be needed in the Azure CLI c
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-setup-env-var.sh[tags=adocEnvironmentVariables2]
 ----
+--
 
 == Ready?
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-local-running-app.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/A-azure-container-apps/azure-local-running-app.adoc
@@ -49,8 +49,8 @@ So, first, be sure that your container system has enough memory to build the exe
 It requires at least 6Gb of memory, 8Gb is recommended.
 ====
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Execute the following commands to build all our microservices and the UI.
 This will build Docker images out of Linux native executables:
 Under the `quarkus-workshop-super-heroes/super-heroes` directory execute the following Docker commands:
@@ -81,13 +81,14 @@ quarkus/rest-fights             latest      198MB
 quarkus/rest-villains           latest      158MB
 quarkus/rest-heroes             latest      154MB
 ----
+--
 
 == (Optional) Running local containers
 
 Now that we have all our Docker containers created, let's execute them all to be sure that everything is working.
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Under `super-heroes/infrastructure` you will find the `docker-compose-app-local.yaml` file.
 It declares all the needed infrastructure (databases, Kafka) as well as our microservices.
 Execute it with:
@@ -132,6 +133,7 @@ Then, make sure you shut down the entire application with:
 ----
 docker compose -f docker-compose-app-local.yaml down
 ----
+--
 
 == (Optional) Pushing containers to Azure Container Registry
 
@@ -142,8 +144,8 @@ Now that we have all our Docker containers running locally, let's push them to A
 Make sure you've set all the environment variables defined in the previous chapter and that you've also created the resource group and the Azure Container Registry.
 ====
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Before you can push an image to your registry, you must tag it with the fully qualified name of your registry login server (the `REGISTRY_URL` variable).
 Tag the image using the `docker tag` commands:
 
@@ -151,9 +153,10 @@ Tag the image using the `docker tag` commands:
 ----
 include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocTagging]
 ----
+--
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 To be able to push these Docker images to Azure Registry, we first need to log in to the registry:
 
 [source,shell,indent=0]
@@ -187,25 +190,29 @@ include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[t
 You can visualize the content of the registry on the https://portal.azure.com[Azure Portal].
 
 image::azure-portal-4.png[]
+--
 
 == Running remote containers
 
 [NOTE]
 ====
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
+[example, role="cta"]
+--
 
 If you haven't skipped the previous optional sections and built the containers your self, you should edit the `docker-compose-app-remote.yaml` file under `super-heroes/infrastructure` and change the name `superheroesregistry` with the value of the `$REGISTRY` variable.
+--
 ====
 
-icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
-
+[example, role="cta"]
+--
 Now that we have all our Docker containers pushed to Azure Container Registry, let's execute them with:
 
 [source,shell]
 ----
 docker compose -f docker-compose-app-remote.yaml up
 ----
-
+--
+s
 Once all the containers are started, you can:
 
 * Go to http://localhost:8080 to check the main UI

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -101,6 +101,31 @@ samp {
   display: block;
 }
 
+.cta > .content {
+  /*We could set a background or other styling for the CTA blocks here,
+  but we also need to undo the default 'example' styling */
+  background-color: white;
+  border: 0px solid white;
+  box-shadow: none;
+  padding: 0;
+}
+
+/*See here for the list of unicode codes for fontawesome*/
+/*https://fontawesome.com/v5/cheatsheet*/
+
+.cta::before {
+  color: #bf0000;
+  vertical-align: top;
+  font-size: larger;
+  font-family: "Font Awesome 5 Free", 'Open Sans', Arial, sans-serif;
+  content: "\f0a4" " Call to action";
+  display: inline-block;
+  padding-right: 3px;
+  padding-top: 7px;
+  padding-bottom: 1.25em;
+  font-weight: 400;
+}
+
 .clipboard {
   display: none;
   border: 0;


### PR DESCRIPTION
We had around a hundred Call To Action markers in the asciidoc. As part of #238, we may want to update them. I also had  some discussions with @insectengine about changing the text and other style updates. Before updating them, it would be nice to move the content and presentation into a common place.

I thought a bit about what the best way to do it is. A simple include? Custom macro? A delimited block? A simple block with some css? I decided to repurpose an example block and use css to get the text and icon in.

Before
<img width="528" alt="image" src="https://github.com/quarkusio/quarkus-workshops/assets/11509290/fb824adc-6014-4de2-a3f1-98b5176b3e74">

The code to generate that is:
```
icon:hand-point-right[role="red", size=2x] [red big]#Call to action#
```
After

<img width="504" alt="image" src="https://github.com/quarkusio/quarkus-workshops/assets/11509290/90da15d6-ff48-4c2d-82d4-c8e1730e946a">

The code to generate that is:
```
[example, role="cta"]
—
```
and then also an end `--` delimiter. I could have done it without the delimiters, but @insectengine thought it would be helpful to visually distinguish ’do stuff’ and ‘read stuff’ sections with more than just a heading. 

Because the content is in a css before pseudo-element, the flexibility is limited. I couldn’t exactly match what we had before, because I had to choose between the solid font awesome icon and the lighter weight on the text. I also had to make the icon a bit smaller. But I think the slight loss of flexibility is worth the DRYness. 

As a side-bonus, using the class and the block technique means we can put, for example, a background on the CTA contents, which is something @insectengine suggested would be helpful. 
