### PR TITLE
Publish repo on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           retention-days: 3
 
       - name: Publication
-        if: "github.repository == 'quarkusio/quarkus-workshops' && github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
+        if: "github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I followed the model of Quarkus and guarded the github pages publication step for forks, but actually, forks usually do want their own published copy. So I've reversed that change.