### PR TITLE
Remove accidental crediting of Holly with the whole workshop

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -2,11 +2,9 @@ image::quarkus-logo.png[]
 
 = Quarkus Super-Heroes Workshop
 
-Holly Cummins
-
 {docdate}: Quarkus {quarkus-version}
 
-Based on a https://github.com/quarkusio/quarkus-workshops[workshop] by Emmanuel Bernard; Clement Escoffier; Antonio Goncalves; Aurea Munoz Hernandez; Georgios Andrianakis v2.0,
+Emmanuel Bernard; Clement Escoffier; Antonio Goncalves; Aurea Munoz Hernandez; Georgios Andrianakis; Holly Cummins
 
 :data-uri:
 :doctype: book


### PR DESCRIPTION
In my fork of the workshop at hollycummins.com/quarkus-workshops, I had my name and a "based on", which made sense in that context. I seem to have accidentally pushed it to the main site, where it's very wrong!