### PR TITLE
Align HeroResource#getRandomHero in code and docs

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/3-reactive/reactive.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/3-reactive/reactive.adoc
@@ -271,9 +271,16 @@ public class HeroResource {
     @GET
     @Path("/random")
     @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Hero.class, required = true)))
-    public Uni<Hero> getRandomHero() {
+    public Uni<RestResponse<Hero>> getRandomHero() {
         return Hero.findRandom()
-            .invoke(h -> logger.debugf("Found random hero: %s", h));
+            .onItem().ifNotNull().transform(h -> {
+                this.logger.debugf("Found random hero: %s", h);
+                return RestResponse.ok(h);
+            })
+            .onItem().ifNull().continueWith(() -> {
+                this.logger.debug("No random villain found");
+                return RestResponse.notFound();
+            });
     }
 
     @Operation(summary = "Returns all the heroes from the database")

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/states.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/5a-contract-testing/states.adoc
@@ -61,15 +61,15 @@ Edit the `HeroResource` and update the `getRandomHere` method to explicitly hand
     @GET
     @Path("/random")
     @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Hero.class, required = true)))
-    public Uni<Response> getRandomHero() {
+    public Uni<RestResponse<Hero>> getRandomHero() {
         return Hero.findRandom()
             .onItem().ifNotNull().transform(h -> {
                 this.logger.debugf("Found random hero: %s", h);
-                return Response.ok(h).build();
+                return RestResponse.ok(h);
             })
             .onItem().ifNull().continueWith(() -> {
                 this.logger.debug("No random villain found");
-                return Response.status(Response.Status.NOT_FOUND).build();
+                return RestResponse.notFound();
             });
     }
 ----

--- a/quarkus-workshop-super-heroes/super-heroes/rest-heroes/src/main/java/io/quarkus/workshop/superheroes/hero/HeroResource.java
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-heroes/src/main/java/io/quarkus/workshop/superheroes/hero/HeroResource.java
@@ -47,15 +47,15 @@ public class HeroResource {
     @GET
     @Path("/random")
     @APIResponse(responseCode = "200", content = @Content(mediaType = APPLICATION_JSON, schema = @Schema(implementation = Hero.class, required = true)))
-    public Uni<Response> getRandomHero() {
+    public Uni<RestResponse<Hero>> getRandomHero() {
         return Hero.findRandom()
             .onItem().ifNotNull().transform(h -> {
                 this.logger.debugf("Found random hero: %s", h);
-                return Response.ok(h).build();
+                return RestResponse.ok(h);
             })
             .onItem().ifNull().continueWith(() -> {
                 this.logger.debug("No random villain found");
-                return Response.status(Response.Status.NOT_FOUND).build();
+                return RestResponse.notFound();
             });
     }
 


### PR DESCRIPTION
The code needs to handle the `null` case
for the Pact tests to pass, so the docs are updated. Furthermore, we use `RestResponse` instead of
`Response` because it's typed and because
the rest of the class uses it

Closes: #274