### PR TITLE
Fix Adoc header

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -23,6 +23,7 @@ Emmanuel Bernard; Clement Escoffier; Antonio Goncalves; Aurea Munoz Hernandez; G
 :use-linux: true
 :use-windows: true
 //:use-local-kubernetes: true
+:front-cover-image: image:quarkus-logo.png[]
 // /!\ The document header may not contain empty lines. The first empty line the processor encounters after the document header begins marks the end of the document header and the start of the document body. https://docs.asciidoctor.org/asciidoc/latest/document/header/
 
 image::quarkus-logo.png[]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -1,11 +1,5 @@
-image::quarkus-logo.png[]
-
-= Quarkus Super-Heroes Workshop
-
-{docdate}: Quarkus {quarkus-version}
-
+= Quarkus Super-Heroes Workshop: {docdate} Quarkus {quarkus-version}
 Emmanuel Bernard; Clement Escoffier; Antonio Goncalves; Aurea Munoz Hernandez; Georgios Andrianakis; Holly Cummins
-
 :data-uri:
 :doctype: book
 :source-highlighter: coderay
@@ -24,12 +18,14 @@ Emmanuel Bernard; Clement Escoffier; Antonio Goncalves; Aurea Munoz Hernandez; G
 :full-width: role=full-width
 :half-width: role=half-width
 :half-size: role=half-size
-
 // Conditional includes - can be overridden in the build to generate tailored docs
 :use-mac: true
 :use-linux: true
 :use-windows: true
 //:use-local-kubernetes: true
+// /!\ The document header may not contain empty lines. The first empty line the processor encounters after the document header begins marks the end of the document header and the start of the document body. https://docs.asciidoctor.org/asciidoc/latest/document/header/
+
+image::quarkus-logo.png[]
 
 // Introduction
 include::0-introduction/introduction.adoc[leveloffset=+1]


### PR DESCRIPTION
https://docs.asciidoctor.org/asciidoc/latest/document/header/

> The document header may not contain empty lines. The first empty line the processor encounters after the document header begins marks the end of the document header and the start of the document body. 

https://docs.asciidoctor.org/asciidoc/latest/document/subtitle/

> The HTML 5 converter does not currently split the subtitle out from the document title when generating HTML from AsciiDoc. The document title is only partitioned into a main and subtitle in the output of the DocBook, EPUB 3, and PDF converters.