### PR TITLE
Dependabot does not recurse, so set correct path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: maven
-    directory: /
+    directory: /quarkus-workshop-super-heroes
     open-pull-requests-limit: 40
     schedule:
-      interval: weekly
+      interval: daily
     labels:
       - "version-upgrade"
     pull-request-branch-name:


### PR DESCRIPTION
See discussion in https://github.com/dependabot/dependabot-core/issues/2178 and https://github.com/quarkusio/quarkus-workshops/issues/313. It seems that setting dependabot to a root directory with no pom.xml in it gives ... no PRs. So I've set it to look in the highest directory that has a pom.xml.

I've set the frequency to daily since hopefully the number of PRs will be the same, and it will avoid the need for manual updates if we want an update quicker.