### PR TITLE
Update quinoa to work around slow downloads

### DIFF
--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/pom.xml
@@ -31,7 +31,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.4.1</quarkus.platform.version>
-        <quinoa.version>2.1.0</quinoa.version>
+        <quinoa.version>2.2.0.CR1</quinoa.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>


### PR DESCRIPTION
Resolves #275 - or rather, @ia3andy thinks that the latest Quinoa release, which includes https://github.com/quarkiverse/quarkus-quinoa/pull/513, should not suffer from slow node downloads anymore. (They've replaced the download manager with a different, more reliable, one.)

@agoncal let's try this and see if it helps you.