### PR TITLE
Avoid hardcoding surefire version, reduce hardcoding of JDK version

### DIFF
--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -44,6 +44,7 @@
         <quarkus.pact.version>1.0.1.Final</quarkus.pact.version>
         <semantic-kernel.version>0.2.8-alpha</semantic-kernel.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
+        <surefire-plugin.version>3.1.2</surefire-plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
@@ -122,6 +123,12 @@
                         <artifactId>quarkus-pact-provider</artifactId>
                         <version>${quarkus.pact.version}</version>
                     </dependency>
+                    <dependency>
+                        <!-- Yes, depending on a plugin is a bit unusual; it's so dependabot can manage it without affecting the docs build -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire-plugin.version}</version>
+                    </dependency>
                 </dependencies>
                 <configuration>
                     <requires>
@@ -155,7 +162,8 @@
                         <graalvm-version>22.3</graalvm-version>
                         <maven-version>3.8.x</maven-version>
                         <quarkus-version>${quarkus.platform.version}</quarkus-version>
-                        <compiler-version>${compiler-plugin.version}</compiler-version>
+                        <compiler-plugin-version>${compiler-plugin.version}</compiler-plugin-version>
+                        <surefire-plugin-version>${surefire-plugin.version}</surefire-plugin-version>
                         <quarkus-pact-version>${quarkus.pact.version}</quarkus-pact-version>
                         <semantic-kernel-version>${semantic-kernel.version}</semantic-kernel-version>
                     </attributes>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-graalvm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-graalvm.adoc
@@ -130,7 +130,7 @@ endif::use-mac[]
 
 == Checking for GraalVM Installation
 
-Once installed and set up, you should be able to run the following command and get the following output.
+Once installed and set up, you should be able to run the following command and get something like the following output.
 
 [source,shell]
 ----

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-jdk.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-jdk.adoc
@@ -82,12 +82,12 @@ endif::use-mac[]
 
 ifdef::use-linux[]
 For Linux distributions, there are also packaged java installations.
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 # dnf (rpm-based)
-dnf install java-17-openjdk
+dnf install java-{jdk-version}-openjdk
 # Debian-based distributions:
-$ apt-get install openjdk-17-jdk
+$ apt-get install openjdk-{jdk-version}-jdk
 ----
 endif::use-linux[]
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-bootstrapping.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-bootstrapping.adoc
@@ -120,15 +120,15 @@ In addition, you can see the `quarkus-maven-plugin` responsible for the packagin
 <project>
   <!-- ... -->
   <properties>
-    <compiler-plugin.version>3.11.0</compiler-plugin.version>
-    <maven.compiler.release>17</maven.compiler.release>
+    <compiler-plugin.version>{compiler-plugin-version}</compiler-plugin.version>
+    <maven.compiler.release>{jdk-version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>{quarkus-version}</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.1.2</surefire-plugin.version>
+    <surefire-plugin.version>{surefire-plugin-version}</surefire-plugin.version>
   </properties>
   <!-- ... -->
   <dependencyManagement>
@@ -250,12 +250,12 @@ $ ./mvnw quarkus:dev
 [INFO] Invoking resources:{quarkus-version}:resources (default-resources) @ rest-villains
 [INFO] Copying 2 resources from src/main/resources to target/classes
 [INFO] Invoking quarkus:{quarkus-version}:generate-code (default) @ rest-villains
-[INFO] Invoking compiler:{compiler-version}:compile (default-compile) @ rest-villains
+[INFO] Invoking compiler:{compiler-plugin-version}:compile (default-compile) @ rest-villains
 [INFO] Nothing to compile - all classes are up to date
 [INFO] Invoking resources:{quarkus-version}:testResources (default-testResources) @ rest-villains
 [INFO] skip non existing resourceDirectory /Users/agoncal/Documents/Code/Temp/quarkus-super-heroes/super-heroes/rest-villains/src/test/resources
 [INFO] Invoking quarkus:{quarkus-version}:generate-code-tests (default) @ rest-villains
-[INFO] Invoking compiler:{compiler-version}:testCompile (default-testCompile) @ rest-villains
+[INFO] Invoking compiler:{compiler-plugin-version}:testCompile (default-testCompile) @ rest-villains
 [INFO] Nothing to compile - all classes are up to date
 Listening for transport dt_socket at address: 5005
 


### PR DESCRIPTION
I spotted when checking https://github.com/quarkusio/quarkus-workshops/pull/329 that we do hardcode the surefire plugin version in the docs. I've updated it to use a dependabot-manageable variable. 

I also noticed that we have hardcoding for the compiler plugin version, so I fixed that. There was also hardcoding of the JDK version but that was too hard to fix without actually running command in the build and scraping the output, so I fixed what I could and left the rest. 