### PR TITLE
Extend native guard to also cover installing graalvm

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-jdk.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-jdk.adoc
@@ -96,12 +96,14 @@ endif::use-linux[]
 Once the installation is complete, it is necessary to set the `JAVA_HOME` variable and the `$JAVA_HOME/bin` directory to the `PATH` variable.
 Check that your system recognizes Java by entering `java -version` and the Java compiler with `javac -version`.
 
-[source,shell]
+[source,shell,subs="attributes+"]
 ----
 $ java -version
 openjdk version "17.0.5" 2022-10-18
+ifdef::use-native[]
 OpenJDK Runtime Environment GraalVM CE 22.3.0 (build 17.0.5+8-jvmci-22.3-b08)
 OpenJDK 64-Bit Server VM GraalVM CE 22.3.0 (build 17.0.5+8-jvmci-22.3-b08, mixed mode, sharing)
+endif::use-native[]
 
 $ javac -version
 javac 17.0.5

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-rancher.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-rancher.adoc
@@ -1,4 +1,3 @@
-ifdef::use-local-kubernetes[]
 
 [[introduction-installing-rancher]]
 
@@ -112,4 +111,3 @@ Stop the port forwarding using `CTRL+C`, and delete the pod:
 (CTRL+C)
 $ kubectl delete pod hello-ngnix
 ----
-endif::use-local-kubernetes[]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing.adoc
@@ -5,9 +5,13 @@ include::introduction-installing-jdk.adoc[leveloffset=+1]
 
 include::introduction-installing-docker.adoc[leveloffset=+1]
 
+ifdef::use-native[]
 include::introduction-installing-graalvm.adoc[leveloffset=+1]
+endif::use-native[]
 
+ifdef::use-local-kubernetes[]
 include::introduction-installing-rancher.adoc[leveloffset=+1]
+endif::use-local-kubernetes[]
 
 ifdef::use-ai[]
 include::introduction-installing-ai.adoc[leveloffset=+1]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing.adoc
@@ -24,7 +24,9 @@ Before going further, make sure the following commands work on your machine.
 [source,shell]
 ----
 java -version
+ifdef::use-native[]
 $GRAALVM_HOME/bin/native-image --version
+endif::use-native[]
 curl --version
 docker version
 docker compose version

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-presentation.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-presentation.adoc
@@ -149,17 +149,18 @@ If you are using Mac OS X, make sure the version is greater than 10.11.x (El Cap
 ====
 endif::use-mac[]
 
-This workshop will make use of the following software, tools, frameworks that you will need to install and now (more or less) how it works:
+This workshop will make use of the following software, tools, frameworks that you will need to install and know (more or less) how it works:
 
 * Any IDE you feel comfortable with (eg. Intellij IDEA, Eclipse IDE, VS Code..)
 * JDK {jdk-version}
+ifdef::use-native[]
 * GraalVM {graalvm-version}
-* Docker
+endif::use-native[]
+* Docker or Podman
 * cURL (or any other command line HTTP client)
 ifdef::use-ai[]
 * OpenAI or Azure OpenAI keys (optional, only if you want to use the narration feature)
 endif::use-ai[]
-* Angular (optional, only if you are in a _frontend_ mood)
 
 We will also be using Maven {maven-version}, but there is no
 need to install it. Instead, the workshop scaffolding includes


### PR DESCRIPTION
I spotted that we still ask people to install GraalVM, even if the native guard is active. Graal does have some use as a JVM, but I don't think we're going there, so I've just guarded that install section. 

I also moved the rancher guard to the parent doc instead of in the rancher doc, just to be consistent with what we're doing on other guards.