### PR TITLE
Have proper values for sdkman install

### DIFF
--- a/quarkus-workshop-super-heroes/.sdkmanrc
+++ b/quarkus-workshop-super-heroes/.sdkmanrc
@@ -1,0 +1,4 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.7-tem
+quarkus=3.3.0

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -157,6 +157,7 @@
                         <github-issue>${github.issue}</github-issue>
                         <github-issue>${base.url}</github-issue>
                         <give-solution>true</give-solution>
+                        <sdk-java>${sdk-java}</sdk-java>
                         <jdk-version>${maven.compiler.source}</jdk-version>
                         <!-- NOTE! Any version listed here should have an entry in the dependencies, so that dependabot keeps docs in sync with implementation -->
                         <graalvm-version>22.3</graalvm-version>
@@ -262,6 +263,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.2.0</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>read-project-properties</goal>
+            </goals>
+            <configuration>
+              <keyPrefix>sdk-</keyPrefix>
+              <files>
+                <file>../.sdkmanrc</file>
+              </files>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
             <!-- This is here so that dependabot manages it -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-jdk.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-jdk.adoc
@@ -65,18 +65,18 @@ There are several different vendors of Java, and each vendor has its own distrib
 Most of these distributions are available on SDKMAN! and can easily be installed.
 Let's install Temurin.
 
-To install Temurin {jdk-version}, we copy its identifier (`{jdk-version}-tem`), which is the version from the table, and we add it as an argument in the install command:
+To install Temurin {jdk-version}, we copy its identifier (`{sdk-java}`), which is the version from the table, and we add it as an argument in the install command:
 
 [source,term,subs="attributes+"]
 ----
-$ sdk install java {jdk-version}-tem
+$ sdk install java {sdk-java}
 
-Downloading: java {jdk-version}-tem
-Repackaging Java {jdk-version}-tem...
-Installing: java {jdk-version}-tem
+Downloading: java {sdk-java}
+Repackaging Java {sdk-java}...
+Installing: java {sdk-java}
 Done installing!
 
-Do you want java {jdk-version}-tem to be set as default? (Y/n):
+Do you want java {sdk-java} to be set as default? (Y/n):
 ----
 endif::use-mac[]
 


### PR DESCRIPTION
Why:

 * sdk instructions used 17-tem instead of 17.0.1-tem

This change addreses the need by:

 * add .sdkmanrc with proper values
   - allows you to do `sdk env` to install java and quarkus cli
 * loads .sdkmanrc into maven build providing values to {sdk-java}
   in the docs


Fixes #288 