### PR TITLE
Do not use remote content for includes if it is available locally

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-ai.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-ai.adoc
@@ -65,7 +65,7 @@ Then, execute the following command to create the Azure OpenAI resources:
 
 [source,bash]
 ----
-include::../../../../../super-heroes/infrastructure/ai-azure-openai-create.sh[tags=adocSetup;!adocSkip]
+include::{projectdir}/infrastructure/ai-azure-openai-create.sh[tags=adocSetup;!adocSkip]
 ----
 
 This script will create the Azure OpenAI resource and deploy the model.
@@ -74,12 +74,12 @@ You will need these properties later one when you will configure the Narration m
 
 [source,bash]
 ----
-include::../../../../../super-heroes/infrastructure/ai-azure-openai-create.sh[tag=adocProperties]
+include::{projectdir}/infrastructure/ai-azure-openai-create.sh[tag=adocProperties]
 ----
 
 Once you've finished the workshop, remember to delete the Azure OpenAI resources to avoid being charged for it:
 
 [source,bash]
 ----
-include::../../../../../super-heroes/infrastructure/ai-azure-openai-delete.sh[tag=adocDelete]
+include::{projectdir}/infrastructure/ai-azure-openai-delete.sh[tag=adocDelete]
 ----

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest-client/rest-clients.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest-client/rest-clients.adoc
@@ -255,7 +255,7 @@ So, to mock the `VillainProxy` interface we just need to implement the following
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/MockVillainProxy.java[]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/MockVillainProxy.java[]
 ----
 
 We are using some common classes for the test data.
@@ -266,7 +266,7 @@ manually, and then fill in the following contents:
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/DefaultTestVillain.java[]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/DefaultTestVillain.java[]
 ----
 
 
@@ -285,7 +285,7 @@ We'll still want a class which holds test data for the hero. Create the followin
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/DefaultTestHero.java[]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/DefaultTestHero.java[]
 ----
 
 
@@ -324,7 +324,7 @@ Finally, edit the `FightResourceTest` and add the following method:
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceTest.java[tag=shouldGetRandomFighters]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceTest.java[tag=shouldGetRandomFighters]
 ----
 
 Now, run the test from the dev mode, or from your IDE.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-ai/ai.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-ai/ai.adoc
@@ -179,7 +179,7 @@ Create the `io.quarkus.workshop.superheroes.narration.Fight` class in the create
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/Fight.java[]
+include::{projectdir}/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/Fight.java[]
 ----
 --
 
@@ -194,7 +194,7 @@ Open the generated `io.quarkus.workshop.superheroes.narration.NarrationResource`
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/NarrationResource.java[]
+include::{projectdir}/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/NarrationResource.java[]
 ----
 --
 
@@ -210,7 +210,7 @@ Open the `NarrationResource` and update the content to be:
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/NarrationService.java[]
+include::{projectdir}/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/NarrationService.java[]
 ----
 
 Then, create the `io.quarkus.workshop.superheroes.narration.SemanticKernelNarrationService` that implements the `NarrationService` interface.
@@ -222,7 +222,7 @@ This class has the following methods:
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/SemanticKernelNarrationService.java[]
+include::{projectdir}/rest-narration/src/main/java/io/quarkus/workshop/superheroes/narration/SemanticKernelNarrationService.java[]
 ----
 --
 
@@ -245,14 +245,14 @@ Notice that the prompt uses expression language to get the fight data (e.g., `{{
 
 [source,text]
 ----
-include::../../../../../super-heroes/rest-narration/src/main/resources/NarrationSkill/NarrateFight/skprompt.txt[]
+include::{projectdir}/rest-narration/src/main/resources/NarrationSkill/NarrateFight/skprompt.txt[]
 ----
 
 Under `src/main/resources/NarrationSkill/NarrateFight/`, create the `config.json` file with the following content:
 
 [source,json]
 ----
-include::../../../../../super-heroes/rest-narration/src/main/resources/NarrationSkill/NarrateFight/config.json[]
+include::{projectdir}/rest-narration/src/main/resources/NarrationSkill/NarrateFight/config.json[]
 ----
 --
 
@@ -286,7 +286,7 @@ Just add the following configuration to the Quarkus `application.properties` fil
 
 [source,properties]
 ----
-include::../../../../../super-heroes/rest-narration/src/main/resources/application.properties[]
+include::{projectdir}/rest-narration/src/main/resources/application.properties[]
 ----
 --
 
@@ -300,7 +300,7 @@ Open the `io.quarkus.workshop.superheroes.narration.NarrationResourceTest` class
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-narration/src/test/java/io/quarkus/workshop/superheroes/narration/NarrationResourceTest.java[]
+include::{projectdir}/rest-narration/src/test/java/io/quarkus/workshop/superheroes/narration/NarrationResourceTest.java[]
 ----
 --
 
@@ -361,7 +361,7 @@ Go back to the `io.quarkus.workshop.superheroes.fight.FightResource` class and a
 
 [source,java,indent=0]
 ----
-include::../../../../../super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightResource.java[tag=adocNarrate]
+include::{projectdir}/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightResource.java[tag=adocNarrate]
 ----
 
 The `FightResource` invokes a new method of the `FightService`.
@@ -369,21 +369,21 @@ Add the following method to the `io.quarkus.workshop.superheroes.fight.FightServ
 
 [source,java,indent=0]
 ----
-include::../../../../../super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java[tag=adocNarrate]
+include::{projectdir}/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java[tag=adocNarrate]
 ----
 
 Under the `client` package, where all the other proxies are already located, create a new `NarrationProxy` class:
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/client/NarrationProxy.java[]
+include::{projectdir}/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/client/NarrationProxy.java[]
 ----
 
 To link both microservices, we need to add the following configuration to the `rest-fights/src/main/resources/application.properties` file of the fight microservice:
 
 [source,properties]
 ----
-include::../../../../../super-heroes/rest-fights/src/main/resources/application.properties[tag=adocNarrate]
+include::{projectdir}/rest-fights/src/main/resources/application.properties[tag=adocNarrate]
 ----
 --
 
@@ -398,14 +398,14 @@ Add the following `shouldNarrate` test to the `io.quarkus.workshop.superheroes.f
 
 [source,java,indent=0]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceTest.java[tag=adocNarrate]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceTest.java[tag=adocNarrate]
 ----
 
 Create the `io.quarkus.workshop.superheroes.fight.client.MockNarrationProxy` class and add the new `narrateFight` method:
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/MockNarrationProxy.java[]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/client/MockNarrationProxy.java[]
 ----
 --
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-aca-running-app.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-aca-running-app.adoc
@@ -21,7 +21,7 @@ Create the container apps environment with the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateACAEnv]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateACAEnv]
 ----
 --
 
@@ -36,17 +36,17 @@ Create the databases with the following commands:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresH]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresH]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresV]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresV]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresF]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresF]
 ----
 --
 
@@ -57,17 +57,17 @@ Then, we create the database schemas, one for each database:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaH]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaH]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaV]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaV]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaF]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaF]
 ----
 --
 
@@ -81,7 +81,7 @@ Create the tables using the following commands (make sure you are under `quarkus
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableH]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableH]
 ----
 --
 
@@ -93,12 +93,12 @@ Check https://github.com/Azure/azure-cli/issues/21998 for help.
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableV]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableV]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableF]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableF]
 ----
 
 [example, role="cta"]
@@ -108,17 +108,17 @@ Now, let's add some super heroes and super villains to these databases:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocImportDataH]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocImportDataH]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocImportDataV]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocImportDataV]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocImportDataF]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocImportDataF]
 ----
 
 
@@ -126,17 +126,17 @@ You can check the content of the tables with the following commands:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataH]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataH]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataV]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataV]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataF]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataF]
 ----
 --
 
@@ -150,21 +150,21 @@ We need to create an Azure event hub for that.
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateEventHub]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateEventHub]
 ----
 
 Then, create the Kafka topic where the messages will be sent to and consumed from:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocCreateEventHubTopic]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateEventHubTopic]
 ----
 
 To configure Kafka in the Fight and Statistics microservices, get the connection string with the following commands:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-aca-env.sh[tags=adocEventHubConnection]
+include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocEventHubConnection]
 ----
 
 If you log into the https://portal.azure.com[Azure Portal] you should see the following created resources.
@@ -216,7 +216,7 @@ Create the Heroes container app with the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppHero]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppHero]
 ----
 
 
@@ -224,7 +224,7 @@ The following command sets the URL of the deployed application to the `HEROES_UR
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppHeroURL]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppHeroURL]
 ----
 
 You can now invoke the Hero microservice APIs with:
@@ -239,7 +239,7 @@ To access the logs of the Heroes microservice, you can write the following query
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppHeroLogs]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppHeroLogs]
 ----
 --
 
@@ -260,14 +260,14 @@ Notice the minimum of replicas is also set to 0:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppVillain]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppVillain]
 ----
 
 The following command sets the URL of the deployed application to the `VILLAINS_URL` variable:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppVillainURL]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppVillainURL]
 ----
 
 You can now invoke the Hero microservice APIs with:
@@ -282,7 +282,7 @@ To access the logs of the Villain microservice, you can write the following quer
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppVillainLogs]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppVillainLogs]
 ----
 --
 
@@ -297,14 +297,14 @@ Create the Statistics container application with the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppStatistics]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppStatistics]
 ----
 
 The following command sets the URL of the deployed application to the `STATISTICS_URL` variable:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppStatisticsURL]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppStatisticsURL]
 ----
 
 You can now display the Statistics UI with:
@@ -318,7 +318,7 @@ To access the logs of the Statistics microservice, you can write the following q
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppStatisticsLogs]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppStatisticsLogs]
 ----
 --
 
@@ -335,14 +335,14 @@ Create the Fights container application with the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppFight]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppFight]
 ----
 
 The following command sets the URL of the deployed application to the `FIGHTS_URL` variable:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppFightURL]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppFightURL]
 ----
 
 Use the following curl commands to access the Fight microservice.
@@ -362,7 +362,7 @@ To access the logs of the Fight microservice, you can write the following query:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppFightLogs]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppFightLogs]
 ----
 
 === Super Hero UI
@@ -378,12 +378,12 @@ For now, let's continue with Azure Container Apps and deploy the UI as a Docker 
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppUI]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppUI]
 ----
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppUIURL]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppUIURL]
 ----
 
 [source,shell]
@@ -396,7 +396,7 @@ To access the UI logs, you can write the following query:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-deploy-aca.sh[tags=adocAppUILogs]
+include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppUILogs]
 ----
 
 == Running the Application

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-intro-preparing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-intro-preparing.adoc
@@ -79,7 +79,7 @@ Make sure you are using the right subscription with:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocAzAccountShow]
+include::{projectdir}/infrastructure/azure-setup-azure-env.sh[tags=adocAzAccountShow]
 ----
 --
 
@@ -155,7 +155,7 @@ Set the following variables:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-env-var.sh[tags=adocEnvironmentVariables]
+include::{projectdir}/infrastructure/azure-setup-env-var.sh[tags=adocEnvironmentVariables]
 ----
 
 Now let's create the Azure resources.
@@ -174,7 +174,7 @@ Execute the following command to create the Super Hero resource group:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocCreateResourceGroup]
+include::{projectdir}/infrastructure/azure-setup-azure-env.sh[tags=adocCreateResourceGroup]
 ----
 --
 
@@ -190,14 +190,14 @@ Create a Log Analytics workspace with the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocCreateLogAnalytics]
+include::{projectdir}/infrastructure/azure-setup-azure-env.sh[tags=adocCreateLogAnalytics]
 ----
 
 Let's also retrieve the Log Analytics Client ID and client secret and store them in environment variables:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocLogAnalyticsSecrets]
+include::{projectdir}/infrastructure/azure-setup-azure-env.sh[tags=adocLogAnalyticsSecrets]
 ----
 --
 
@@ -214,21 +214,21 @@ First, let's created an Azure Container Registry with the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocCreateContainerRegistry]
+include::{projectdir}/infrastructure/azure-setup-azure-env.sh[tags=adocCreateContainerRegistry]
 ----
 
 Update the repository to allow anonymous users to pull the images:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocAnonymousContainerRegistry]
+include::{projectdir}/infrastructure/azure-setup-azure-env.sh[tags=adocAnonymousContainerRegistry]
 ----
 
 Get the URL of the Azure Container Registry and set it to the `REGISTRY_URL` variable with the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-azure-env.sh[tags=adocContainerRegistryURL]
+include::{projectdir}/infrastructure/azure-setup-azure-env.sh[tags=adocContainerRegistryURL]
 ----
 
 If you log into the https://portal.azure.com[Azure Portal] you should see the following created resources.
@@ -248,7 +248,7 @@ Set the following environment variables, there will be needed in the Azure CLI c
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-setup-env-var.sh[tags=adocEnvironmentVariables2]
+include::{projectdir}/infrastructure/azure-setup-env-var.sh[tags=adocEnvironmentVariables2]
 ----
 --
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-local-running-app.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-local-running-app.adoc
@@ -57,11 +57,11 @@ Under the `quarkus-workshop-super-heroes/super-heroes` directory execute the fol
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocCompiling]
+include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocCompiling]
 ----
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocBuilding]
+include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocBuilding]
 ----
 
 Check that you have all the Docker images installed locally:
@@ -151,7 +151,7 @@ Tag the image using the `docker tag` commands:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocTagging]
+include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocTagging]
 ----
 --
 
@@ -161,7 +161,7 @@ To be able to push these Docker images to Azure Registry, we first need to log i
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocLogging]
+include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocLogging]
 ----
 
 You should see the prompt _Login Succeeded_.
@@ -170,21 +170,21 @@ Then, push all the images with the following commands:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocPushing]
+include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocPushing]
 ----
 
 You can check that the images have been pushed to Azure Container Registry by executing the following command:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocListing]
+include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocListing]
 ----
 
 You can also get some information on a particular repository or image if needed:
 
 [source,shell,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/azure-build-push-registry.sh[tags=adocShowing]
+include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocShowing]
 ----
 
 You can visualize the content of the registry on the https://portal.azure.com[Azure Portal].

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-happy-path-consumer-tests.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-happy-path-consumer-tests.adoc
@@ -38,7 +38,7 @@ Create a class called `FightResourceConsumerTest.java`.
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=skeleton]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=skeleton]
 
     @Test
     void randomHeroFound() {
@@ -59,7 +59,7 @@ You'll notice this is very similar to the one in `FightResourceTest`; you could 
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=randomHeroFound]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=randomHeroFound]
 ----
 
 Run the tests.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-states.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-states.adoc
@@ -14,7 +14,7 @@ We use the `given()` to identify the state.
 [source,java]
 
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=randomHeroNotFoundPact]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=randomHeroNotFoundPact]
 ----
 
 Then, we can define another test method, which exercises our service, given this unhappy state.
@@ -23,7 +23,7 @@ We also want to check that things work as normal for the villain part of the res
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=randomHeroNotFoundTest]
+include::{projectdir}/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java[tags=randomHeroNotFoundTest]
 ----
 
 Run the tests. They should pass. Then copy them to the hero service, using `cp -r target/pacts ../rest-heroes/src/test/resources`.
@@ -35,7 +35,7 @@ so we'll work around it by handling the state in the `@BeforeEach`.
 
 [source,java]
 ----
-include::../../../../../super-heroes/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroContractVerificationTest.java[tags=states]
+include::{projectdir}/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroContractVerificationTest.java[tags=states]
 }
 ----
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-healthcheck.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-healthcheck.adoc
@@ -183,7 +183,7 @@ Because we defined our health check to be a liveness procedure (with `@Liveness`
 //
 //[source]
 //----
-//include::{github-raw}/super-heroes/rest-heroes/src/main/java/io/quarkus/workshop/superheroes/hero/health/DatabaseConnectionHealthCheck.java[tags=adocDatabaseConnection]
+//include::{projectdir}/rest-heroes/src/main/java/io/quarkus/workshop/superheroes/hero/health/DatabaseConnectionHealthCheck.java[tags=adocDatabaseConnection]
 //----
 //
 //If you now rerun the health check at http://localhost:8083/q/health/live the checks array will contain only the previously defined `PingHeroResourceHealthCheck` as it is the only check defined with the `@Liveness` qualifier.
@@ -217,7 +217,7 @@ Because we defined our health check to be a liveness procedure (with `@Liveness`
 //
 //[source,indent=0]
 //----
-//include::{github-raw}/super-heroes/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroResourceTest.java[tags=adocHealth]
+//include::{projectdir}/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroResourceTest.java[tags=adocHealth]
 //----
 
 [NOTE]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-load.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-load.adoc
@@ -17,7 +17,7 @@ For example, if you look at the `HeroScenario`, you will see that it's just a su
 
 [source,indent=0]
 ----
-include::{github-raw}/super-heroes/load-super-heroes/src/main/java/io/quarkus/workshop/superheroes/load/HeroScenario.java[tag=adocScenario]
+include::{projectdir}/load-super-heroes/src/main/java/io/quarkus/workshop/superheroes/load/HeroScenario.java[tag=adocScenario]
 ----
 
 == Running the Load Application

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-metrics.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-metrics.adoc
@@ -24,7 +24,7 @@ This will add the following dependency in the `pom.xml` file:
 
 [source,xml,indent=0]
 ----
-include::../../../../../super-heroes/rest-heroes/pom.xml[tags=adocDependencyMetrics]
+include::{projectdir}/rest-heroes/pom.xml[tags=adocDependencyMetrics]
 ----
 
 == Adding Metrics to HeroResource
@@ -45,7 +45,7 @@ Below the source code of the `getRandomHero()` method, but make sure to add metr
 
 [source,indent=0]
 ----
-include::../../../../../super-heroes/rest-heroes/src/main/java/io/quarkus/workshop/superheroes/hero/HeroResource.java[tags=adocMetricsMethods]
+include::{projectdir}/rest-heroes/src/main/java/io/quarkus/workshop/superheroes/hero/HeroResource.java[tags=adocMetricsMethods]
 ----
 
 [example, role="cta"]
@@ -70,7 +70,7 @@ Let's add an extra test method that would make sure Metrics are available in the
 
 [source,indent=0]
 ----
-include::../../../../../super-heroes/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroResourceTest.java[tags=adocMetrics]
+include::{projectdir}/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/hero/HeroResourceTest.java[tags=adocMetrics]
 ----
 
 == Reviewing the Generated Metrics

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-prometheus.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-observability/observability-prometheus.adoc
@@ -11,7 +11,7 @@ This is made under our `infrastructure` directory, in the `prometheus.yml` file:
 
 [source,yaml,indent=0]
 ----
-include::{github-raw}/super-heroes/infrastructure/monitoring/prometheus.yml[tags=adocPrometheus]
+include::{projectdir}/infrastructure/monitoring/prometheus.yml[tags=adocPrometheus]
 ----
 
 This file contains basic Prometheus configuration, plus a specific `scrape_config` which instructs Prometheus to look for application metrics from both Prometheus itself, and our Quarkus microservices at the `/q/metrics` endpoint.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine-azure.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine-azure.adoc
@@ -20,6 +20,7 @@ v1.0, {docdate}: Quarkus {quarkus-version}
 :full-width: role=full-width
 :half-width: role=half-width
 :half-size: role=half-size
+:projectdir: {docdir}/../../../../super-heroes/
 
 // Introduction
 include::optional-azure-container-apps/azure.adoc[leveloffset=+1]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -20,6 +20,7 @@ Emmanuel Bernard; Clement Escoffier; Antonio Goncalves; Aurea Munoz Hernandez; G
 :full-width: role=full-width
 :half-width: role=half-width
 :half-size: role=half-size
+:projectdir: {docdir}/../../../../super-heroes/
 // Conditional includes - can be overridden in the build to generate tailored docs
 :use-mac:
 :use-linux:


### PR DESCRIPTION
We're seeing errors like the following in PR builds:

```
2023-09-28T08:47:48.8374609Z [INFO] asciidoctor: ERROR: optional-azure-container-apps/azure-intro-preparing.adoc: line 82: include uri not readable: https://raw.githubusercontent.com/quarkusio/quarkus-workshops/refs/pull/345/merge/quarkus-workshop-super-heroes/super-heroes/infrastructure/azure-setup-azure-env.sh
2023-09-28T08:47:49.0207330Z [INFO] asciidoctor: ERROR: optional-azure-container-apps/azure-intro-preparing.adoc: line 158: include uri not readable: https://raw.githubusercontent.com/quarkusio/quarkus-workshops/refs/pull/345/merge/quarkus-workshop-super-heroes/super-heroes/infrastructure/azure-setup-env-var.sh
2023-09-28T08:47:49.1171300Z [INFO] asciidoctor: ERROR: optional-azure-container-apps/azure-intro-preparing.adoc: line 177: include uri not readable: https://raw.githubusercontent.com/quarkusio/quarkus-workshops/refs/pull/345/merge/quarkus-workshop-super-heroes/super-heroes/infrastructure/azure-setup-azure-env.sh
```

The cause is that some of the asciidoc files are pulling includes from GitHub, rather than the local checkout. This has a few problems:

- It doesn’t work when building PRs, and generates lots of errors (and an inaccurate preview)
- It wouldn’t work offline, for example, on the Eurostar :) 
- It’s slow. As we start to run the content generation ~100 times to generate content variations, this makes more of a difference.

I don't think there's any reason we'd ever want the remote version of a file that's available locally, but shout if that's a wrong assumption. 

While I was updating the GitHub includes to be local, I also swapped hardcoded paths to an attribute for all our source includes. That should improve readability.