### PR TITLE
Correct publication path for main site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,4 +107,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./quarkus-workshop-super-heroes/docs/target/site
+          publish_dir: ./target/site


### PR DESCRIPTION
The github PR preview did not exercise a code path which is only run on `main` builds, and that path had an incorrect file path following the build changes in #347. 