### PR TITLE
Styling corrections for configurator

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -14,14 +14,22 @@ blockquote,
 dt,
 td.content,
 span.alt {
-  font-size: medium;
+    font-size: medium;
+}
+
+label {
+    font-weight: normal;
+}
+
+input[type="checkbox"], input[type="radio"] {
+    margin-right: 8px;
 }
 
 #header,
 #content,
 #footnotes,
 #footer {
-  max-width: 90.5em;
+    max-width: 90.5em;
 }
 
 /*There's a font override on these, which we need to de-override*/

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -59,11 +59,6 @@ a[data-toggle='collapse'] {
   margin-bottom: 10px;
 }
 
-h1 {
-  font-size: 46px;
-  font-weight: bold;
-}
-
 #toctitle,
 .h1,
 .h2,
@@ -83,21 +78,34 @@ h6 {
 }
 
 h3, h4, .h3, .h4 {
-  border-bottom: 1px solid darkblue;
-  padding-top: 0.2em;
+    border-bottom: 1px solid darkblue;
+    padding-top: 0.2em;
 }
 
 h1 {
-  margin: .67em 0;
-  font-size: 1.5em;
+    margin: .67em 0;
+    font-size: 2em;
+    font-weight: bold;
+}
+
+h2 {
+    font-size: 1.6em;
+}
+
+h3 {
+    font-size: 1.5em;
+}
+
+h4 {
+    font-size: 1.4em;
 }
 
 li p {
-  font-size: medium;
+    font-size: medium;
 }
 
 code {
-  color: #c7254e;
+    color: #c7254e;
 }
 
 code,

--- a/quarkus-workshop-super-heroes/docs/src/docs/html/index.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/html/index.html
@@ -11,11 +11,7 @@
         <meta name="description" content="A hands on lab about Quarkus">
 
         <link href="assets/css/bootstrap.css" media="screen" rel="stylesheet">
-        <link href="assets/css/font-awesome.min.css" media="screen" rel="stylesheet">
         <link href="assets/css/hol.css" media="screen" rel="stylesheet">
-        <link href="assets/css/github.css" media="screen" rel="stylesheet">
-        <script src="assets/js/jquery-3.1.1.js"></script>
-        <script src="assets/js/bootstrap.js"></script>
     </head>
     <title>Workshop configurator</title>
     <script>


### PR DESCRIPTION
This change:
- Fixes some duplicated and missing heading styles in the css, so that h2 isn't bigger than h1
- Adds some padding to the checkboxes and radio buttons
- Makes the font on the labels look better 

Before:

<img width="1624" alt="image" src="https://github.com/quarkusio/quarkus-workshops/assets/11509290/766b045d-e223-47d8-9fb2-095e2e5dc6cc">

After:

<img width="1624" alt="image" src="https://github.com/quarkusio/quarkus-workshops/assets/11509290/8f61a7f4-bb43-4b59-b697-8792e2da61f0">

These changes could also affect the main workshop; I've checked and it seems to look ok/the same.