### PR TITLE
Use more reliable download action

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success


### PR DESCRIPTION
Fixes #357 (maybe, if we're lucky). I've noticed on other workflows that the dawid66 download action sometimes downloads the incorrect artifact, which makes life very confusing. That may be what's happening here.

Sadly, we can't test this until we merge it.