### PR TITLE
Trivial styling: Put logo at top of document

### DIFF
--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -139,10 +139,9 @@ The default build will take around 50m.
                             <allow-uri-read/>
                             <toc>left</toc>
                             <linkcss>false</linkcss>
-                            <docinfo1>true</docinfo1>
+                            <docinfo>shared</docinfo>
                             <icons>font</icons>
                             <toclevels>3</toclevels>
-                            <icons>font</icons>
                             <plantDir>../plantuml</plantDir>
                             <github-raw>${github.raw}</github-raw>
                             <github-url>${github.url}</github-url>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/docinfo.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/docinfo.html
@@ -1,51 +1,58 @@
-<meta name="keywords" content="Quarkus, Workshop, Microservice, Kafka">
-<meta name="description" content="A hands on lab about Quarkus">
+<head>
 
-<link href="assets/css/bootstrap.css" media="screen" rel="stylesheet">
-<link href="assets/css/font-awesome.min.css" media="screen" rel="stylesheet">
-<link href="assets/css/hol.css" media="screen" rel="stylesheet">
-<link href="assets/css/github.css" media="screen" rel="stylesheet">
-<script src="assets/js/jquery-3.1.1.js"></script>
-<script src="assets/js/bootstrap.js"></script>
-<!-- be aware that only a few languages have been included-->
-<script src="assets/js/highlight.pack.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
+    <meta name="keywords" content="Quarkus, Workshop, Microservice, Kafka">
+    <meta name="description" content="A hands on lab about Quarkus">
+
+    <link href="assets/css/bootstrap.css" media="screen" rel="stylesheet">
+    <link href="assets/css/font-awesome.min.css" media="screen" rel="stylesheet">
+    <link href="assets/css/hol.css" media="screen" rel="stylesheet">
+    <link href="assets/css/github.css" media="screen" rel="stylesheet">
+    <script src="assets/js/jquery-3.1.1.js"></script>
+    <script src="assets/js/bootstrap.js"></script>
+    <!-- be aware that only a few languages have been included-->
+    <script src="assets/js/highlight.pack.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
 
 
-<script>
-    $(document).ready(function () {
-        hljs.initHighlightingOnLoad();
-        $('pre.highlight code').each(function (i, block) {
-            hljs.highlightBlock(block);
-        });
+    <script>
+        $(document).ready(function () {
+            hljs.initHighlightingOnLoad();
+            $('pre.highlight code').each(function (i, block) {
+                hljs.highlightBlock(block);
+            });
 
-        var pre = document.getElementsByTagName('pre');
-        for (var i = 0; i < pre.length; i++) {
-            var b = document.createElement('button');
-            b.className = 'clipboard';
-            b.textContent = 'Copy';
-            if (pre[i].childNodes.length === 1 && pre[i].childNodes[0].nodeType === 3) {
-                var div = document.createElement('div');
-                div.textContent = pre[i].textContent;
-                pre[i].textContent = '';
-                pre[i].appendChild(div);
+            var pre = document.getElementsByTagName('pre');
+            for (var i = 0; i < pre.length; i++) {
+                var b = document.createElement('button');
+                b.className = 'clipboard';
+                b.textContent = 'Copy';
+                if (pre[i].childNodes.length === 1 && pre[i].childNodes[0].nodeType === 3) {
+                    var div = document.createElement('div');
+                    div.textContent = pre[i].textContent;
+                    pre[i].textContent = '';
+                    pre[i].appendChild(div);
+                }
+                pre[i].appendChild(b);
             }
-            pre[i].appendChild(b);
-        }
-        var clipboard = new ClipboardJS('.clipboard', {
-            target: function (b) {
-                var p = b.parentNode;
-                return p.getElementsByClassName("code")[0]
-                    ? p.getElementsByClassName("code")[0]
-                    : p.childNodes[0];
-            }
+            var clipboard = new ClipboardJS('.clipboard', {
+                target: function (b) {
+                    var p = b.parentNode;
+                    return p.getElementsByClassName("code")[0]
+                        ? p.getElementsByClassName("code")[0]
+                        : p.childNodes[0];
+                }
+            });
+            clipboard.on('success', function (e) {
+                e.clearSelection();
+                e.trigger.textContent = 'Copied';
+                setTimeout(function () {
+                    e.trigger.textContent = 'Copy';
+                }, 2000);
+            });
         });
-        clipboard.on('success', function (e) {
-            e.clearSelection();
-            e.trigger.textContent = 'Copied';
-            setTimeout(function () {
-                e.trigger.textContent = 'Copy';
-            }, 2000);
-        });
-    });
-</script>
+    </script>
+</head>
+<header>
+    <img src="images/quarkus-logo.png" alt="Quarkus Logo"/>
+</header>
+

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -50,8 +50,6 @@ endif::[]
 
 // /!\ The document header may not contain empty lines. The first empty line the processor encounters after the document header begins marks the end of the document header and the start of the document body. https://docs.asciidoctor.org/asciidoc/latest/document/header/
 
-image::quarkus-logo.png[]
-
 
 // ====================================================
 // ====================== CORE ========================


### PR DESCRIPTION
I looked at what I could do to give the main document more Quarkus-y styling, but didn't have too many ideas that were also small and safe. I wondered about a nice dark blue band at the top, like we have in various places in the main site, but getting it to also go across the table of contents column is a bit more invasive. So I've left it at just putting the logo at the top of the document. It's so trivial it's hardly worth bothering, but it gives us the `<header>` scaffolding to build on. 

(It looks like a lot of changes on the docinfo.html, but it's just indenting everything because of an added `head` element.)