### PR TITLE
Correct hacky css overlaying custom footer on the asciidoc footer

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -36,7 +36,7 @@ html, body {
     --border-radius: 10px;
 
     --site-margins: 13rem;
-
+    --toc-width: 20rem;
 }
 
 body {
@@ -67,6 +67,7 @@ input[type="checkbox"], input[type="radio"] {
 
 #footer, footer {
     height: 42px;
+    width: 100%;
     background-color: black;
     color: var(--white);
     display: flex;
@@ -74,22 +75,11 @@ input[type="checkbox"], input[type="radio"] {
     justify-content: space-between;
     align-items: center;
     font-size: 12px;
-    margin-left: var(--site-margins);
-    margin-right: var(--site-margins);
+    padding-left: calc(var(--toc-width) + var(--site-margins));
+    padding-right: var(--site-margins);
     position: fixed;
     bottom: 0;
-    right: 0;
-}
-
-/*Evil css, sorry. The asciidoc-generated footer and our custom one need to co-exist, so overlay them*/
-footer {
-    z-index: 4;
-    right: 0;
-    width: 700px; /* don't go so far over we interfere with the main toc */
-    justify-content: right;
-    margin-right: 0;
-    padding-right: 100px; /* fudged by eye, we should come back and set this properly */
-
+    right: 0
 }
 
 footer a:visited {
@@ -97,10 +87,6 @@ footer a:visited {
 }
 
 footer a {
-    color: white;
-}
-
-#footer-text {
     color: white;
 }
 
@@ -205,6 +191,10 @@ samp {
 
 }
 
+#toc.toc2 {
+    width: var(--toc-width);
+}
+
 .content-area {
     margin-left: var(--site-margins);
     margin-right: var(--site-margins);
@@ -215,7 +205,7 @@ samp {
     /*We could set a background or other styling for the CTA blocks here,
     but we also need to undo the default 'example' styling */
     background-color: white;
-    border: 0px solid white;
+    border: 0 solid white;
     box-shadow: none;
     padding: 0;
 }

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/docinfo-footer.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/docinfo-footer.html
@@ -1,0 +1,7 @@
+<footer>
+    <div>Last updated {docdate}</div>
+    <div><i class="far fa-comments"></i>&nbsp;Need help? Join the <a
+        href="https://quarkusio.zulipchat.com/#narrow/stream/402952-workshops">
+        Zulip workshop chat</a>
+    </div>
+</footer>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/docinfo.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/docinfo.html
@@ -55,11 +55,3 @@
 <header>
     <img src="{imagesdir}/quarkus-logo.png" alt="Quarkus Logo"/>
 </header>
-
-<footer>
-    <div><i class="far fa-comments"></i>&nbsp;Need help? Join the <a
-        href="https://quarkusio.zulipchat.com/#narrow/stream/402952-workshops">Zulip workshop
-        chat</a>
-    </div>
-</footer>
-

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -9,6 +9,8 @@ Emmanuel Bernard; Clement Escoffier; Antonio Goncalves; Aurea Munoz Hernandez; G
 :figure-caption: Figure
 :table-caption: Table
 :xrefstyle: short
+// No footer, because we control it completely in docinfo-footer
+:nofooter:
 // TOC
 :toc:
 :toclevels: 2


### PR DESCRIPTION
As part of #366, we customised the zulip footer, but because there was a bit of a deadline, the css was not pretty. This PR tidies it up a bit by removing  the asciidoc footer so we don't need to do fragile overlays.

With these changes, the css no longer says "sorry" in a comment. :)