### PR TITLE
Avoid button confusion by having a single button on the configurator

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -249,7 +249,7 @@ button:hover {
 .big {
     width: 60%;
     height: 60px;
-    margin-top: 1em;
+    margin-top: 2em;
     margin-bottom: 1em;
     padding: 1em;
     font-size: 1.2em;

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -5,7 +5,6 @@ html, body {
     font-family: 'Open Sans', Arial, sans-serif;
 
     --quarkus-blue: #4695EB;
-    --quarkus-blue-tint: #a3caf5;
     --dark-blue: #09131E;
     --dark-blue-alt: #0D1C2C;
     --dark-blue-1: #205894;
@@ -38,8 +37,6 @@ html, body {
 
     --site-margins: 13rem;
     --toc-width: 20rem;
-
-    --shimmer-duration: 0.3s;
 }
 
 body {
@@ -207,7 +204,25 @@ samp {
 .content-area {
     margin-left: var(--site-margins);
     margin-right: var(--site-margins);
-    width: 60%;
+    display: flex;
+    flex-direction: row;
+    column-gap: 1em;
+
+}
+
+.mode {
+    width: 50%;
+    padding-top: 0em;
+    padding-left: 4em;
+    padding-right: 4em;
+    margin: 3em;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.right {
+    border-left: 1px lightgrey solid;
 }
 
 .cta > .content {
@@ -247,7 +262,7 @@ button:hover {
 }
 
 .big {
-    width: 60%;
+    width: 95%;
     height: 60px;
     margin-top: 2em;
     margin-bottom: 1em;
@@ -258,126 +273,14 @@ button:hover {
     justify-content: center;
 }
 
-.anchor {
-    width: 100%;
-    height: 1.2em; /* this should be the same height as the font size of what is in the anchor */
-    position: relative;
+.no-underline {
+    border: none;
 }
 
-.fadingin {
-    position: absolute;
-    left: 0;
-    right: 0;
-    background-color: white; /* confusingly, this is actually the text color because of the background clip */
-    opacity: 1;
-
-    background-repeat: no-repeat;
-    -webkit-text-fill-color: transparent;
-    -webkit-background-clip: text;
-    -webkit-animation-name: fade-in;
-    -webkit-animation-duration: var(--shimmer-duration);
-    -webkit-animation-iteration-count: 1;
-    -webkit-background-size: 8em 100%; /*50px*/
-
+.squish {
+    margin-top: 0rem;
+    padding-top: 0rem;
 }
-
-.fadingout {
-    position: absolute;
-    background-color: white; /* confusingly, this is actually the text color because of the background clip */
-    -webkit-text-fill-color: transparent;
-    -webkit-background-clip: text;
-    -webkit-animation-name: fade-out;
-    -webkit-animation-duration: var(--shimmer-duration);
-    -webkit-animation-iteration-count: 1;
-    opacity: 0;
-}
-
-.flash {
-    -webkit-animation-name: flash;
-    -webkit-animation-duration: var(--shimmer-duration);
-    -webkit-animation-iteration-count: 1;
-}
-
-.fadeable {
-    position: absolute;
-    left: 0;
-    right: 0;
-    background-color: white; /* confusingly, this is actually the text color because of the background clip */
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-}
-
-.faded {
-    opacity: 0;
-    position: absolute;
-    left: 0;
-    right: 0;
-}
-
-@-webkit-keyframes flash {
-    0% {
-        background: var(--quarkus-blue);
-    }
-
-    50% {
-        background: radial-gradient(var(--quarkus-blue-tint), var(--quarkus-blue));
-    }
-
-    100% {
-        background: var(--quarkus-blue);
-    }
-}
-
-/* This animation works by applying a gradient to the background, and using a text-clip so that the background
-is actually the foreground.
- */
-@-webkit-keyframes fade-in {
-    0% {
-        background: radial-gradient(white, var(--quarkus-blue));
-        -webkit-text-fill-color: transparent;
-        -webkit-background-clip: text;
-        opacity: 0;
-    }
-
-    50% {
-        background: radial-gradient(white, var(--quarkus-blue));
-        -webkit-text-fill-color: transparent;
-        -webkit-background-clip: text;
-        opacity: 0.5
-    }
-
-    100% {
-        background: radial-gradient(white, var(--quarkus-blue));
-        -webkit-text-fill-color: transparent;
-        -webkit-background-clip: text;
-        opacity: 1;
-    }
-}
-
-
-@-webkit-keyframes fade-out {
-    0% {
-        background: radial-gradient(var(--quarkus-blue), white);
-        -webkit-text-fill-color: transparent;
-        -webkit-background-clip: text;
-        opacity: 1;
-    }
-
-    70% {
-        background: radial-gradient(var(--quarkus-blue), white);
-        -webkit-text-fill-color: transparent;
-        -webkit-background-clip: text;
-        opacity: 0.7
-    }
-
-    100% {
-        background: radial-gradient(var(--quarkus-blue), white);
-        -webkit-text-fill-color: transparent;
-        -webkit-background-clip: text;
-        opacity: 0;
-    }
-}
-
 
 /*See here for the list of unicode codes for fontawesome*/
 /*https://fontawesome.com/v5/cheatsheet*/
@@ -434,5 +337,7 @@ pre code, pre pre {
 }
 
 ul.configurator {
-  list-style-type: none;
+    list-style-type: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
 }

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/assets/css/hol.css
@@ -5,6 +5,7 @@ html, body {
     font-family: 'Open Sans', Arial, sans-serif;
 
     --quarkus-blue: #4695EB;
+    --quarkus-blue-tint: #a3caf5;
     --dark-blue: #09131E;
     --dark-blue-alt: #0D1C2C;
     --dark-blue-1: #205894;
@@ -37,6 +38,8 @@ html, body {
 
     --site-margins: 13rem;
     --toc-width: 20rem;
+
+    --shimmer-duration: 0.3s;
 }
 
 body {
@@ -245,10 +248,134 @@ button:hover {
 
 .big {
     width: 60%;
+    height: 60px;
     margin-top: 1em;
     margin-bottom: 1em;
     padding: 1em;
     font-size: 1.2em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.anchor {
+    width: 100%;
+    height: 1.2em; /* this should be the same height as the font size of what is in the anchor */
+    position: relative;
+}
+
+.fadingin {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background-color: white; /* confusingly, this is actually the text color because of the background clip */
+    opacity: 1;
+
+    background-repeat: no-repeat;
+    -webkit-text-fill-color: transparent;
+    -webkit-background-clip: text;
+    -webkit-animation-name: fade-in;
+    -webkit-animation-duration: var(--shimmer-duration);
+    -webkit-animation-iteration-count: 1;
+    -webkit-background-size: 8em 100%; /*50px*/
+
+}
+
+.fadingout {
+    position: absolute;
+    background-color: white; /* confusingly, this is actually the text color because of the background clip */
+    -webkit-text-fill-color: transparent;
+    -webkit-background-clip: text;
+    -webkit-animation-name: fade-out;
+    -webkit-animation-duration: var(--shimmer-duration);
+    -webkit-animation-iteration-count: 1;
+    opacity: 0;
+}
+
+.flash {
+    -webkit-animation-name: flash;
+    -webkit-animation-duration: var(--shimmer-duration);
+    -webkit-animation-iteration-count: 1;
+}
+
+.fadeable {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background-color: white; /* confusingly, this is actually the text color because of the background clip */
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.faded {
+    opacity: 0;
+    position: absolute;
+    left: 0;
+    right: 0;
+}
+
+@-webkit-keyframes flash {
+    0% {
+        background: var(--quarkus-blue);
+    }
+
+    50% {
+        background: radial-gradient(var(--quarkus-blue-tint), var(--quarkus-blue));
+    }
+
+    100% {
+        background: var(--quarkus-blue);
+    }
+}
+
+/* This animation works by applying a gradient to the background, and using a text-clip so that the background
+is actually the foreground.
+ */
+@-webkit-keyframes fade-in {
+    0% {
+        background: radial-gradient(white, var(--quarkus-blue));
+        -webkit-text-fill-color: transparent;
+        -webkit-background-clip: text;
+        opacity: 0;
+    }
+
+    50% {
+        background: radial-gradient(white, var(--quarkus-blue));
+        -webkit-text-fill-color: transparent;
+        -webkit-background-clip: text;
+        opacity: 0.5
+    }
+
+    100% {
+        background: radial-gradient(white, var(--quarkus-blue));
+        -webkit-text-fill-color: transparent;
+        -webkit-background-clip: text;
+        opacity: 1;
+    }
+}
+
+
+@-webkit-keyframes fade-out {
+    0% {
+        background: radial-gradient(var(--quarkus-blue), white);
+        -webkit-text-fill-color: transparent;
+        -webkit-background-clip: text;
+        opacity: 1;
+    }
+
+    70% {
+        background: radial-gradient(var(--quarkus-blue), white);
+        -webkit-text-fill-color: transparent;
+        -webkit-background-clip: text;
+        opacity: 0.7
+    }
+
+    100% {
+        background: radial-gradient(var(--quarkus-blue), white);
+        -webkit-text-fill-color: transparent;
+        -webkit-background-clip: text;
+        opacity: 0;
+    }
 }
 
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
@@ -20,46 +20,6 @@
         const baseUrl = "./";
         const filename = "spine.html"
 
-        /* It's easy for people to click the most prominent button, but if they've set options they should
-         * be choosing the less prominent button at the bottom. Fix this by making the big button go away.
-         */
-        function hideDefaultButton() {
-            const button = document.querySelector(`button`);
-            button.addEventListener('click', generateTailoredURL)
-
-            const originalText = document.querySelector(`.fadeable`);
-            if (originalText) {
-                // Only flash if there was originalText to change
-                button.classList.toggle('flash')
-
-                originalText.classList.toggle('fadingout');
-                originalText.classList.toggle('fadeable');
-            }
-
-            const replacementText = document.querySelector(`.faded`);
-            if (replacementText) {
-                replacementText.classList.toggle('faded');
-                replacementText.classList.toggle('fadingin');
-            }
-
-        }
-
-        function hideDefaultButtonNoAnimation() {
-            const button = document.querySelector(`button`);
-            button.addEventListener('click', generateTailoredURL)
-
-            const originalText = document.querySelector(`.fadeable`);
-            if (originalText) {
-                originalText.hidden = true;
-            }
-
-            const replacementText = document.querySelector(`.faded`);
-            if (replacementText) {
-                replacementText.classList.toggle('faded');
-            }
-
-        }
-
         function generateDefaultURL() {
             const url = baseUrl + filename
             window.location.href = url;
@@ -89,82 +49,89 @@
     </script>
 </head>
 <body>
-<h1 class="title-band">Quarkus Workshop Configurator</h1>
+<h2 class="title-band">Quarkus Workshop Configurator</h2>
 
 <div class="content-area">
-    <button id="fadeable" class="big" onclick="generateDefaultURL()">
-        <!--            spacing help for absolutely positioned children-->
-        <div class="anchor">
-            <div class="fadeable">Just take me to the default workshop
-            </div>
-            <div class="faded">Take me to my custom workshop
-            </div>
-        </div>
-    </button>
+    <div class="mode">
+        <h3 class="no-underline squish">Default workshop configuration</h3>
+        <div>Go to the instructions for all operating systems, with default content.</div>
+        <button class="big" onclick="generateDefaultURL()">
+            Take me to the default workshop
+        </button>
+    </div>
+    <div class="mode right">
+        <h3 class="no-underline squish">Customize workshop</h3>
+        <div>Tailor instructions to your operating system and interests.</div>
 
-    <h2><i class="fas fa-desktop"></i>What operating system are you using?</h2>
-    <ul class="configurator">
-        <li>
-            <label for="macRadio">
-                <input type="radio" name="osOption" id="macRadio" value="mac" onClick="hideDefaultButton()"><i
-                class="fab fa-apple"></i>MacOS
-            </label>
-        </li>
-        <li>
-            <label for="windowsRadio">
-                <input type="radio" name="osOption" id="windowsRadio" value="windows" onClick="hideDefaultButton()"><i
-                class="fab fa-windows"></i>Windows
-            </label>
-        </li>
-        <li>
-            <label for="linuxRadio">
-                <input type="radio" name="osOption" id="linuxRadio" value="linux" onClick="hideDefaultButton()"><i
-                class="fab fa-linux"></i>Linux
-            </label></li>
-    </ul>
+        <h4 class="no-underline"><i class="fas fa-desktop"></i>What operating system are you using?</h4>
+        <ul class="configurator">
+            <li>
+                <label for="macRadio">
+                    <input type="radio" name="osOption" id="macRadio" value="mac"><i
+                    class="fab fa-apple"></i>MacOS
+                </label>
+            </li>
+            <li>
+                <label for="windowsRadio">
+                    <input type="radio" name="osOption" id="windowsRadio" value="windows"><i
+                    class="fab fa-windows"></i>Windows
+                </label>
+            </li>
+            <li>
+                <label for="linuxRadio">
+                    <input type="radio" name="osOption" id="linuxRadio" value="linux"><i
+                    class="fab fa-linux"></i>Linux
+                </label></li>
+        </ul>
 
 
-    <h2 id="feature-selector"><i class="fas fa-book"></i>What content would you like to include in the workshop?</h2>
-    <ul class="configurator">
-        <li id="use-native-li">
-            <label>
-                <input type="checkbox" id="use-native" onClick="hideDefaultButton()">Native compilation
-            </label>
-        </li>
-        <li id="use-ai-li">
-            <label>
-                <input type="checkbox" id="use-ai" onClick="hideDefaultButton()">Creating an AI-integration service
-            </label>
-        </li>
-        <li id="use-kubernetes-li">
-            <label>
-                <input type="checkbox" id="use-kubernetes" onClick="hideDefaultButton()">Running Quarkus on Kubernetes
-            </label>
-        </li>
-        <li>
-        <li id="use-contract-testing-li">
-        <label>
-            <input type="checkbox" id="use-contract-testing" onClick="hideDefaultButton()">Contract testing with
-            Pact
-        </label>
-        </li>
-        <li id="use-observability-li" hidden="true">
-            <label>
-                <input type="checkbox" id="use-observability" onClick="hideDefaultButton()">Observability
-            </label>
-        </li>
-        <li id="use-messaging-li">
-            <label>
-                <input type="checkbox" id="use-messaging" onClick="hideDefaultButton()">Messaging
-            </label>
-        </li>
-        <li id="use-extension-li">
-            <label>
-                <input type="checkbox" id="use-extension" onClick="hideDefaultButton()">Writing an extension
-            </label>
-        </li>
-    </ul>
-
+        <h4 class="no-underline" id="feature-selector"><i class="fas fa-book"></i>What content would you like to
+            include?
+        </h4>
+        <ul class="configurator">
+            <li id="use-native-li">
+                <label>
+                    <input type="checkbox" id="use-native">Native compilation
+                </label>
+            </li>
+            <li id="use-ai-li">
+                <label>
+                    <input type="checkbox" id="use-ai">Creating an AI-integration service
+                </label>
+            </li>
+            <li id="use-kubernetes-li">
+                <label>
+                    <input type="checkbox" id="use-kubernetes">Running Quarkus on
+                    Kubernetes
+                </label>
+            </li>
+            <li>
+            <li id="use-contract-testing-li">
+                <label>
+                    <input type="checkbox" id="use-contract-testing">Contract testing with
+                    Pact
+                </label>
+            </li>
+            <li id="use-observability-li" hidden="true">
+                <label>
+                    <input type="checkbox" id="use-observability">Observability
+                </label>
+            </li>
+            <li id="use-messaging-li">
+                <label>
+                    <input type="checkbox" id="use-messaging">Messaging
+                </label>
+            </li>
+            <li id="use-extension-li">
+                <label>
+                    <input type="checkbox" id="use-extension">Writing an extension
+                </label>
+            </li>
+        </ul>
+        <button class="big" onclick="generateTailoredURL()">
+            Take me to my custom workshop
+        </button>
+    </div>
 </div>
 
 <script>
@@ -172,7 +139,6 @@
     const hideDefined = urlParams.get("hideDefined")?.toLowerCase() === "true";
     for (const [key, value] of urlParams.entries()) {
         if (key === "os") {
-            hideDefaultButtonNoAnimation()
             const input = document.querySelector(`input[id="${value}Radio"]`)
             if (input) {
                 input.checked = true;
@@ -180,7 +146,6 @@
         } else {
             const input = document.querySelector(`input[id="use-${key}"]`)
             if (input) {
-                hideDefaultButtonNoAnimation()
                 if (value && value.toLowerCase() === "true") {
                     input.checked = true;
                 } else {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
@@ -44,6 +44,22 @@
 
         }
 
+        function hideDefaultButtonNoAnimation() {
+            const button = document.querySelector(`button`);
+            button.addEventListener('click', generateTailoredURL)
+
+            const originalText = document.querySelector(`.fadeable`);
+            if (originalText) {
+                originalText.hidden = true;
+            }
+
+            const replacementText = document.querySelector(`.faded`);
+            if (replacementText) {
+                replacementText.classList.toggle('faded');
+            }
+
+        }
+
         function generateDefaultURL() {
             const url = baseUrl + filename
             window.location.href = url;
@@ -156,6 +172,7 @@
     const hideDefined = urlParams.get("hideDefined")?.toLowerCase() === "true";
     for (const [key, value] of urlParams.entries()) {
         if (key === "os") {
+            hideDefaultButtonNoAnimation()
             const input = document.querySelector(`input[id="${value}Radio"]`)
             if (input) {
                 input.checked = true;
@@ -163,6 +180,7 @@
         } else {
             const input = document.querySelector(`input[id="use-${key}"]`)
             if (input) {
+                hideDefaultButtonNoAnimation()
                 if (value && value.toLowerCase() === "true") {
                     input.checked = true;
                 } else {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
@@ -20,12 +20,36 @@
         const baseUrl = "./";
         const filename = "spine.html"
 
+        /* It's easy for people to click the most prominent button, but if they've set options they should
+         * be choosing the less prominent button at the bottom. Fix this by making the big button go away.
+         */
+        function hideDefaultButton() {
+            const button = document.querySelector(`button`);
+            button.addEventListener('click', generateTailoredURL)
+
+            const originalText = document.querySelector(`.fadeable`);
+            if (originalText) {
+                // Only flash if there was originalText to change
+                button.classList.toggle('flash')
+
+                originalText.classList.toggle('fadingout');
+                originalText.classList.toggle('fadeable');
+            }
+
+            const replacementText = document.querySelector(`.faded`);
+            if (replacementText) {
+                replacementText.classList.toggle('faded');
+                replacementText.classList.toggle('fadingin');
+            }
+
+        }
+
         function generateDefaultURL() {
             const url = baseUrl + filename
             window.location.href = url;
         }
 
-        function generateURL() {
+        function generateTailoredURL() {
             const selectedOptions = [];
 
             // Get the selected build option
@@ -44,7 +68,6 @@
             // Generate the URL based on selected options
             const url = baseUrl + 'variants/' + selectedOptions.join("-") + "/" + filename;
             window.location.href = url;
-
         }
 
     </script>
@@ -53,23 +76,34 @@
 <h1 class="title-band">Quarkus Workshop Configurator</h1>
 
 <div class="content-area">
-    <button class="big" onclick="generateDefaultURL()">Just take me to the default workshop</button>
+    <button id="fadeable" class="big" onclick="generateDefaultURL()">
+        <!--            spacing help for absolutely positioned children-->
+        <div class="anchor">
+            <div class="fadeable">Just take me to the default workshop
+            </div>
+            <div class="faded">Take me to my custom workshop
+            </div>
+        </div>
+    </button>
 
     <h2><i class="fas fa-desktop"></i>What operating system are you using?</h2>
     <ul class="configurator">
         <li>
             <label for="macRadio">
-                <input type="radio" name="osOption" id="macRadio" value="mac"><i class="fab fa-apple"></i>MacOS
+                <input type="radio" name="osOption" id="macRadio" value="mac" onClick="hideDefaultButton()"><i
+                class="fab fa-apple"></i>MacOS
             </label>
         </li>
         <li>
             <label for="windowsRadio">
-                <input type="radio" name="osOption" id="windowsRadio" value="windows"><i class="fab fa-windows"></i>Windows
+                <input type="radio" name="osOption" id="windowsRadio" value="windows" onClick="hideDefaultButton()"><i
+                class="fab fa-windows"></i>Windows
             </label>
         </li>
         <li>
             <label for="linuxRadio">
-                <input type="radio" name="osOption" id="linuxRadio" value="linux"><i class="fab fa-linux"></i>Linux
+                <input type="radio" name="osOption" id="linuxRadio" value="linux" onClick="hideDefaultButton()"><i
+                class="fab fa-linux"></i>Linux
             </label></li>
     </ul>
 
@@ -78,43 +112,43 @@
     <ul class="configurator">
         <li id="use-native-li">
             <label>
-                <input type="checkbox" id="use-native">Native compilation
+                <input type="checkbox" id="use-native" onClick="hideDefaultButton()">Native compilation
             </label>
         </li>
         <li id="use-ai-li">
             <label>
-                <input type="checkbox" id="use-ai">Creating an AI-integration service
+                <input type="checkbox" id="use-ai" onClick="hideDefaultButton()">Creating an AI-integration service
             </label>
         </li>
         <li id="use-kubernetes-li">
             <label>
-                <input type="checkbox" id="use-kubernetes">Running Quarkus on Kubernetes
+                <input type="checkbox" id="use-kubernetes" onClick="hideDefaultButton()">Running Quarkus on Kubernetes
             </label>
         </li>
         <li>
         <li id="use-contract-testing-li">
-            <label>
-                <input type="checkbox" id="use-contract-testing">Contract testing with Pact
-            </label>
+        <label>
+            <input type="checkbox" id="use-contract-testing" onClick="hideDefaultButton()">Contract testing with
+            Pact
+        </label>
         </li>
         <li id="use-observability-li" hidden="true">
             <label>
-                <input type="checkbox" id="use-observability">Observability
+                <input type="checkbox" id="use-observability" onClick="hideDefaultButton()">Observability
             </label>
         </li>
-    <li id="use-messaging-li">
+        <li id="use-messaging-li">
             <label>
-                <input type="checkbox" id="use-messaging">Messaging
+                <input type="checkbox" id="use-messaging" onClick="hideDefaultButton()">Messaging
             </label>
         </li>
-    <li id="use-extension-li">
+        <li id="use-extension-li">
             <label>
-                <input type="checkbox" id="use-extension">Writing an extension
+                <input type="checkbox" id="use-extension" onClick="hideDefaultButton()">Writing an extension
             </label>
         </li>
     </ul>
 
-    <button onClick="generateURL()">Take me to my custom workshop</button>
 </div>
 
 <script>

--- a/quarkus-workshop-super-heroes/docs/src/resource-generation/qrcode.java
+++ b/quarkus-workshop-super-heroes/docs/src/resource-generation/qrcode.java
@@ -20,6 +20,11 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * To invoke this, run jbang https://github
+ * .com/quarkusio/quarkus-workshops/blob/main/quarkus-workshop-super-heroes/docs/src/resource
+ * -generation/qrcode.java https://shattereddisk.github.io/rickroll/ mycode.png
+ */
 class qrcode {
 
     // We can do either 1color or rgb


### PR DESCRIPTION
Resolves #371 

We noticed in the workshop, and @insectengine noticed it too, that having two buttons on the configurator is confusing. We want a big button people can push to bypass selection, but we also want people to push the 'take me to my tailored workshop' button if they've made selections. I'd wondered about different button positions or moving buttons, but I think the simplest thing might be to have one button, that just does the right thing. 

I was originally going to make the ‘take me to the default’ option disappear once a button had been clicked, but it either caused a layout jump, or left a big blank spot. Then I realised that no one would use the ‘take me to the custom’ workshop unless they’d chosen something, so we could have both buttons in the same place, and only show the relevant one.

Three things are lost doing it this way; 
- To get an ‘everything’ workshop people have to manually click each box, and of course that might not even be what we have defined as our default
- There’s also no way for people to get an ‘all os’ workshop once they’ve clicked one radio button. However, both of these can be fixed just by reloading the page. I think the tradeoff is worth it for the improved usability. 
- If someone wanted all OSes but no features, they couldn’t do that at all, even with a reload. They could click and unclick a feature box, but it’s a bit of a hack.

If it really bothers us we could add an ‘all’ radio button, but for now I think it would be just clutter.

To draw attention to the fact that the mean of the button has changed, I put a little animation which does a radial fade-out of the outgoing text and a radial fade-in of the incoming text. I also put a little flash on to further smooth the transition and draw attention. 

To test this, go to the front page and try clicking on the selection fields.