### PR TITLE
Automatically detect correct build profile (no more -Pcomplete)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,9 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Microservices build with Maven
-        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pcomplete
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml
       - name: Native build with Maven
-        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
-      - name: Extension build with Maven
-        run: mvn -B install -f quarkus-workshop-super-heroes/super-heroes/extension-version/pom.xml
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs -pl '!:rest-narration,!:extension-version'
   docs:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Skeleton build with Maven
         run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
       - name: Microservices build with Maven
-        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pcomplete
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml
       - name: Extension build with Maven
         run: mvn -B install -f quarkus-workshop-super-heroes/super-heroes/extension-version/pom.xml
   publication:

--- a/quarkus-workshop-super-heroes/README.adoc
+++ b/quarkus-workshop-super-heroes/README.adoc
@@ -43,8 +43,7 @@ $ docker compose rm
 To build the entire code, you need to run the following commands from the root project (also see how we activate the `complete` profile):
 
 ```bash
-$ mvn clean install -f super-heroes/extension-version
-$ mvn clean install -Pcomplete
+$ mvn clean install
 ```
 
 == Running the complete system

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-presentation.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-presentation.adoc
@@ -134,26 +134,6 @@ If you are stuck, you can always look at the final code in the {github-url}[GitH
 
 Oh, and be ready to have some fun!
 
-
-=== The completed workshop
-
-If you want to build the completed workshop, after you've unzipped the {github-raw}/dist/quarkus-super-heroes-workshop-complete.zip[`quarkus-super-heroes-workshop-complete.zip`] file, you would need to run the following command from the root project:
-
-[source, shell]
-----
-$ ./mvnw clean install -Pcomplete
-----
-
-ifdef::use-extension[]
-The extension can be built with the following command:
-
-[source, shell]
-----
-$ ./mvnw clean install -f super-heroes/extension-version
-----
-endif::use-extension[]
-
-
 == Software Requirements
 
 First of all, make sure you have a 64-bit computer with admin rights (so you can install all the needed tools) and at least 8Gb of RAM (as some tools need a few resources).

--- a/quarkus-workshop-super-heroes/pom.xml
+++ b/quarkus-workshop-super-heroes/pom.xml
@@ -102,6 +102,11 @@
     <profiles>
         <profile>
             <id>complete</id>
+            <activation>
+                <file>
+                    <exists>super-heroes/extension-version</exists>
+                </file>
+            </activation>
             <modules>
                 <module>super-heroes/extension-version</module>
                 <module>super-heroes/rest-villains</module>
@@ -114,6 +119,13 @@
         </profile>
         <profile>
             <id>core</id>
+            <activation>
+                <file>
+                    <missing>super-heroes/extension-version</missing>
+                    <exists>super-heroes/rest-villains</exists>
+                    <!-- We do the selection this way around, because if this profile triggers in the complete case, the reactor order ends up wrong when the next profile triggers-->
+                </file>
+            </activation>
             <modules>
                 <module>super-heroes/rest-villains</module>
                 <module>super-heroes/rest-heroes</module>
@@ -121,8 +133,14 @@
             </modules>
         </profile>
         <profile>
-            <id>full</id>
+            <id>full</id> <!-- Needs to be manually invoked or it will trigger in the CI, #280 should fix -->
             <modules>
+                <module>super-heroes/extension-version</module>
+                <module>super-heroes/rest-villains</module>
+                <module>super-heroes/rest-heroes</module>
+                <module>super-heroes/rest-fights</module>
+                <module>super-heroes/event-statistics</module>
+                <module>super-heroes/rest-narration</module>
                 <module>docs</module>
             </modules>
         </profile>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-villains/src/main/docker/Dockerfile.build-native
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-villains/src/main/docker/Dockerfile.build-native
@@ -21,7 +21,7 @@ USER quarkus
 WORKDIR /code
 COPY --chown=quarkus:quarkus . ${WORKDIR}
 
-RUN ./mvnw -B clean install -DskipTests -Pcomplete -pl :extension-version-parent -amd
+RUN ./mvnw -B clean install -DskipTests -pl :extension-version-parent -amd
 RUN ./mvnw -B clean package -f super-heroes/rest-villains -DskipTests -Pnative
 
 ## Stage 2 : create the docker final image


### PR DESCRIPTION
Resolves #233
Resolves #378

I think the reason we originally had profiles is that depending what zip they extract, sometimes people have lots of modules, sometimes they have a small number, and maven does not allow us to define optional modules, or just do a “build all subfolders” command. 

The [mvn docs](https://maven.apache.org/guides/introduction/introduction-to-profiles.html#profile-order) say:

> All profile elements in a POM from active profiles overwrite the global elements with the same name of the POM or extend those in case of collections. In case multiple profiles are active in the same POM or external file, the ones which are defined later take precedence over the ones defined earlier (independent of their profile id and activation order).

So anything we define in a profile will add to anything we define in the main pom, but profiles won’t add to each other, and we need to define them in order. 

We can only define one ‘guard’ file per profile. The good news is that limits the combinatorics, and we have to assume a limited number of ‘profiles’ (as it were!) to cater for. This does mean if someone is midway through building the workshop and tries a top-level build, it will fail because of missing projects or, depending what guard file we choose, not build everything.

This is annoying, but no worse than where we were before. At least builds of the extracted zips will work. 

Well, they would build if it wasn’t for #280. I’ll fix that next, and also add some tests to make sure the zips can actually build, since it seems like core technical capability. 