### PR TITLE
Exclude narration and extension from native build in zips workflow

### DIFF
--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Skeleton build with Maven
-        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs
+        run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs -pl '!:rest-narration,!:extension-version'
       - name: Microservices build with Maven
         run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml
       - name: Extension build with Maven


### PR DESCRIPTION
I've mirrored the logic from the main build.yml to the zips build, which isn't exercised on PRs. 

This is a tactical fix, since ideally the top level build wouldn't even attempt to build narration if the profile is native. However, the combinatorics of all the profiles gets a bit complex, so I will do the tactical fix for now.