### PR TITLE
Test improvements

### DIFF
--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/package-lock.json
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/package-lock.json
@@ -20,7 +20,8 @@
         "@testing-library/dom": "^8.20.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "^14.4.3"
+        "@testing-library/user-event": "^14.4.3",
+        "babel-preset-react-app": "^10.0.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/package.json
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/package.json
@@ -42,7 +42,8 @@
     "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^14.4.3"
+    "@testing-library/user-event": "^14.4.3",
+    "babel-preset-react-app": "^10.0.1"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/App.test.js
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/App.test.js
@@ -1,10 +1,80 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import App from "./App";
-import "@testing-library/jest-dom";
+import React from "react"
+import {render, screen} from "@testing-library/react"
+import App from "./App"
+import "@testing-library/jest-dom"
+import {act} from "react-dom/test-utils"
+import {getFights, getRandomFighters} from "./shared/api/fight-service"
 
-test("renders a suitable title", () => {
-  render(<App />);
-  const titleElement = screen.getByText(/Super Heroes/i);
-  expect(titleElement).toBeInTheDocument();
-});
+jest.mock("./shared/api/fight-service")
+
+const fighters = {
+  hero: {
+    name: 'Fake hero',
+    level: 1,
+    picture: 'https://dummyimage.com/280x380/1e8fff/ffffff&text=Fake+Hero',
+    powers: 'Fake hero powers'
+  },
+  villain: {
+    name: 'Fake villain',
+    level: 42,
+    picture: 'https://dummyimage.com/280x380/b22222/ffffff&text=Fake+Villain',
+    powers: 'Fake villain powers'
+  }
+}
+
+const location = {
+  name: "Gotham City",
+  picture: 'https://dummyimage.com/280x380/b22222/ffffff&text=Gotham',
+  description: "This is Gotham City"
+}
+
+const fight = {
+  fightDate: "2023-10-24T21:34:47.617598Z",
+  id: 200,
+  loserLevel: 1,
+  loserName: "Some hero",
+  loserPicture: "https://dummyimage.com/280x380/1e8fff/ffffff&text=Mock+Hero",
+  loserPowers: "Being fake",
+  loserTeam: "heroes",
+  winnerLevel: 42,
+  winnerName: "Some villain",
+  winnerPicture: "https://dummyimage.com/280x380/b22222/ffffff&text=Mock+Villain",
+  winnerPowers: "Dissimulation",
+  winnerTeam: "villains",
+  location: location
+}
+
+describe("renders the elements", () => {
+  beforeEach(() => {
+    getRandomFighters.mockResolvedValue(fighters)
+    getFights.mockResolvedValue([fight])
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders a suitable title', async () => {
+    await act(async () => {
+      render(<App/>)
+    })
+
+    expect(screen.getByText(/Super Heroes/i)).toBeInTheDocument()
+  })
+
+  it("renders a table with column headings", async () => {
+    await act(async () => {
+      render(<App/>)
+    })
+    expect(screen.getByText("Fight Date")).toBeInTheDocument()
+  })
+
+  it("renders fighters", async () => {
+    await act(async () => {
+      render(<App/>)
+    })
+    expect(screen.getByText("Fake hero")).toBeInTheDocument()
+    expect(screen.getByText("Fake villain")).toBeInTheDocument()
+    expect(screen.getByText(/FIGHT !/)).toBeInTheDocument()
+  })
+})

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight-list/FightList.test.js
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight-list/FightList.test.js
@@ -1,5 +1,5 @@
 import React from "react"
-import {render, screen} from "@testing-library/react"
+import {render, screen, within} from "@testing-library/react"
 import "@testing-library/jest-dom"
 import {FightList} from "./FightList"
 import {getFights} from "../shared/api/fight-service"
@@ -36,10 +36,31 @@ describe("the fight list", () => {
     await act(async () => {
       render(<FightList/>)
     })
-    expect(screen.getByText(/Winner/i)).toBeInTheDocument()
-    expect(screen.getByText(/Loser/i)).toBeInTheDocument()
-    expect(screen.getByText(/Fight Date/i)).toBeInTheDocument()
 
+    const table = screen.getByRole("table")
+    expect(table).toBeInTheDocument()
+
+    const thead = within(table).getAllByRole('rowgroup')[0]
+    const headRows = within(thead).getAllByRole("row")
+    const headCols = within(headRows[0]).getAllByRole("columnheader")
+
+    const numCols = 4
+
+    expect(headCols).toHaveLength(numCols)
+    expect(headCols[0]).toHaveTextContent("Id")
+    expect(headCols[1]).toHaveTextContent("Fight Date")
+    expect(headCols[2]).toHaveTextContent("Winner")
+    expect(headCols[3]).toHaveTextContent("Loser")
+
+    const tbody = within(table).getAllByRole('rowgroup')[1]
+    const bodyRows = within(tbody).getAllByRole('row')
+    const rowCols = within(bodyRows[0]).getAllByRole("cell")
+
+    expect(rowCols).toHaveLength(numCols)
+    expect(rowCols[0]).toHaveTextContent(fight.id)
+    expect(rowCols[1]).toHaveTextContent(fight.fightDate)
+    expect(rowCols[2]).toHaveTextContent(fight.winnerName)
+    expect(rowCols[3]).toHaveTextContent(fight.loserName)
   })
 
   it("renders rows for the fights", async () => {

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/shared/api/fight-service.js
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/shared/api/fight-service.js
@@ -8,8 +8,8 @@ import axios from "axios"
 
 const defaultHeaders = {'Content-Type': "application/json"}
 
-let basePath = window.APP_CONFIG.API_BASE_URL
-const calculateApiBaseUrl = window.APP_CONFIG.CALCULATE_API_BASE_URL
+let basePath = window.APP_CONFIG?.API_BASE_URL
+const calculateApiBaseUrl = window.APP_CONFIG?.CALCULATE_API_BASE_URL
 
 if (calculateApiBaseUrl) {
   // If calculateApiBaseUrl then just replace "ui-super-heroes" with "rest-fights" in the current URL

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/test/java/io/quarkus/workshop/superheroes/ui/WebUITests.java
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/test/java/io/quarkus/workshop/superheroes/ui/WebUITests.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.matchesPattern;
  * The `Enable` test profile enables the Web UI (build and serve).
  */
 @QuarkusTest
-@TestProfile(QuinoaTestProfiles.Enable.class)
+@TestProfile(QuinoaTestProfiles.EnableAndRunTests.class)
 public class WebUITests {
 
     @Test


### PR DESCRIPTION
- Run node.js tests from maven build
- Add new tests, following example in https://github.com/quarkusio/quarkus-super-heroes/pull/408
- Add null guards so the tests pass (not sure how these tests passed locally before, but I remember running them ...)

I didn't exactly follow the example in https://github.com/quarkusio/quarkus-super-heroes/pull/408 since the React Testing Library folks recommend testing from a user perspective, and using test ids as a last resort. This means the tests need to hardcode more strings and are a bit brittle and coupled, so I'm not totally sold on this as a best practice, but I've adopted it here. 