### PR TITLE
Fix UI widths

### DIFF
--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
@@ -76,7 +76,7 @@ public class FightService {
         logger.warn("Falling back on Hero");
         Hero hero = new Hero();
         hero.name = "Fallback hero";
-        hero.picture = "https://dummyimage.com/280x380/1e8fff/ffffff&text=Fallback+Hero";
+        hero.picture = "https://dummyimage.com/240x320/1e8fff/ffffff&text=Fallback+Hero";
         hero.powers = "Fallback hero powers";
         hero.level = 1;
         return hero;
@@ -86,7 +86,7 @@ public class FightService {
         logger.warn("Falling back on Villain");
         Villain villain = new Villain();
         villain.name = "Fallback villain";
-        villain.picture = "https://dummyimage.com/280x380/b22222/ffffff&text=Fallback+Villain";
+        villain.picture = "https://dummyimage.com/240x320/b22222/ffffff&text=Fallback+Villain";
         villain.powers = "Fallback villain powers";
         villain.level = 42;
         return villain;

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/test/java/io/quarkus/workshop/superheroes/fight/FightResourceConsumerTest.java
@@ -123,7 +123,7 @@ public class FightResourceConsumerTest {
 
         assertEquals(hero.name, "Fallback hero");
         assertEquals(hero.picture,
-            "https://dummyimage.com/280x380/1e8fff/ffffff&text=Fallback+Hero");
+            "https://dummyimage.com/240x320/1e8fff/ffffff&text=Fallback+Hero");
         assertEquals(hero.level, 1);
     }
     // end::randomHeroNotFoundTest[]

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
@@ -39,8 +39,8 @@ function Fight({onFight}) {
     )
   } else
     return (
-      <div className="row" id="fight-row">
-        <div>
+      <div id="fight-row">
+        <div className='character'>
           <div className={winner === fighters.hero.name ? 'hero-winner-card' : 'off'}>
             <h2 className="hero-name">
               {fighters.hero.name}
@@ -84,7 +84,7 @@ function Fight({onFight}) {
           </div>
         </div>
 
-        <div>
+        <div className='character'>
           <div className={winner === fighters.villain.name ? 'villain-winner-card' : 'off'}>
             <h2 className="villain-name">
               {fighters.villain.name}

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/styles.css
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/styles.css
@@ -57,12 +57,10 @@ td {
 }
 
 .rounded {
-  display: inline-block;
-  position: relative;
-  width: 80%;
-  overflow: hidden;
-  border-radius: 50%;
-  margin-bottom: 20px;
+    width: 80%;
+    overflow: hidden;
+    border-radius: 50%;
+    margin-bottom: 20px;
 }
 
 .level {
@@ -121,14 +119,15 @@ td {
   10px 0 50px #FF5B68;
 }
 
-.row {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-}
-
 #fight-row {
-  margin-bottom: 30px;
+    display: grid;
+    grid-template-columns: 2fr 1fr 2fr;
+    grid-auto-flow: column;
+    justify-content: center;
+    margin-left: 2rem;
+    margin-right: 2rem;
+    margin-bottom: 30px;
+    gap: 2rem;
 }
 
 .fight-list-header {
@@ -143,6 +142,9 @@ td {
 
 .powers {
   font-size: xx-large;
+}
+
+.character {
 }
 
 .hero {


### PR DESCRIPTION
Before: 

<img width="459" alt="image" src="https://github.com/quarkusio/quarkus-workshops/assets/11509290/a0e2b599-a17f-4c43-8fbe-b66f036e07b1">

When there's a lot of powers, because the layout is flex and I don't specify widths, it pushes the column wider.

I've switched to grid so we can enforce the columns be the same width. 

With the fallbacks, there was still sometimes a bit of misalignment which I think is because the aspect ratio of the fallback image didn't match, so when you did it with width 80%, it would have a slightly higher height.

