### PR TITLE
Clear narration when requesting new fighters

### DIFF
--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight/Fight.js
@@ -13,11 +13,19 @@ function Fight({onFight}) {
 
 
   const newFighters = () => {
-    getRandomFighters().then(answer => setFighters(answer))
+    getRandomFighters().then(answer => {
+      setFighters(answer)
+      clearPreviousFight()
+    })
   }
 
   const narrate = () => {
     narrateFight(fightResult).then(answer => setNarration(answer))
+  }
+
+  const clearPreviousFight = () => {
+    setNarration(undefined)
+    setFightResult(undefined)
   }
 
   const fight = () => {

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/webui/src/app/fight/Fight.test.js
@@ -79,6 +79,7 @@ describe("the fight visualisation", () => {
       })
       expect(screen.getByText("Fake hero")).toBeInTheDocument()
       expect(screen.getByText("Fake villain")).toBeInTheDocument()
+      expect(screen.queryByText(/NARRATE THE FIGHT/i)).not.toBeInTheDocument()
     })
 
     it("renders a fight button", async () => {
@@ -103,6 +104,7 @@ describe("the fight visualisation", () => {
       expect(screen.getByText(/Winner is/i)).toBeInTheDocument()
       // The winner name is in a span by itself but there should be more occurrences of the name count
       expect(screen.getAllByText("Fake villain")).toHaveLength(nameCount + 1)
+      expect(screen.queryByText(/NARRATE THE FIGHT/i)).toBeInTheDocument()
     })
 
     it("renders narration when the narrate button is clicked", async () => {


### PR DESCRIPTION
Clear the narration when requesting new fighters. Also add some tests for this condition.

Fixes #444 