### PR TITLE
Add assembly* files to the generated ZIP

### DIFF
--- a/quarkus-workshop-super-heroes/assembly.xml
+++ b/quarkus-workshop-super-heroes/assembly.xml
@@ -40,6 +40,7 @@
             </excludes>
             <includes>
                 <include>pom.xml</include>
+                <include>assembly*</include>
                 <include>.editorconfig</include>
                 <include>mvnw*</include>
                 <include>.mvn/wrapper/maven-wrapper.properties</include>


### PR DESCRIPTION
Otherwise it can't compile once unzipped because assembly plugin is in the pom but config files are not.