### PR TITLE
Removing observability from the configurator

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/default-options.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/default-options.adoc
@@ -1,3 +1,5 @@
+// Make sure the defaults here are kept in sync with
+// both generate-attribute-combinations.sh and index.html!
 :os: all
 :use-ai:
 :use-azure:
@@ -8,4 +10,3 @@
 :use-kubernetes:
 :use-messaging:
 :use-native:
-:use-observability:

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html
@@ -87,6 +87,8 @@
         <h4 class="no-underline" id="feature-selector"><i class="fas fa-book"></i>What content would you like to
             include?
         </h4>
+        <!--  NOTE TO ANYONE WHO MAY COME HERE IN THE FUTURE TO CREATE A NEW SECTION -->
+        <!--  Make sure any changes you make here also have corresponding changes in generate-attribute-combinations.sh and default-options.adoc!      -->
         <ul class="configurator">
             <li id="use-ai-li">
                 <label>
@@ -129,12 +131,11 @@
                     <input type="checkbox" id="use-native">Native compilation
                 </label>
             </li>
-            <li>
-            <li id="use-observability-li">
-                <label>
-                    <input type="checkbox" id="use-observability">Observability
-                </label>
-            </li>
+<!--            <li id="use-observability-li">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" id="use-observability">Observability-->
+<!--                </label>-->
+<!--            </li>-->
         </ul>
         <button class="big" onclick="generateTailoredURL()">
             Take me to my custom workshop

--- a/quarkus-workshop-super-heroes/docs/src/resource-generation/generate-attribute-combinations.sh
+++ b/quarkus-workshop-super-heroes/docs/src/resource-generation/generate-attribute-combinations.sh
@@ -3,6 +3,8 @@ set -e
 
 # Define the variable variations
 # To disable a variant, just set it to false, rather than removing it (or remove it everywhere, including the pom and the HTML)
+# NOTE: If you disable it here, you also need to remove it from the configurator: index.html
+# and also from default-options.adoc
 ai=("true" "false")
 azure=("true" "false")
 cli=("false")


### PR DESCRIPTION
Currently if selecting observability from the configurator you are taken to a `404` page. The observability section needs a re-write anyways.