### PR TITLE
Update Quarkus to 3.14.2

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-microservices/microservices-fight.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-microservices/microservices-fight.adoc
@@ -35,7 +35,7 @@ If you open the `pom.xml` file, you will see that the following extensions have 
 * `io.quarkus:quarkus-hibernate-orm-panache`
 * `io.quarkus:quarkus-hibernate-validator`
 * `io.quarkus:quarkus-smallrye-openapi`
-* `io.quarkus:quarkus-smallrye-reactive-messaging-kafka`
+* `io.quarkus:quarkus-messaging-kafka`
 * `io.quarkus:quarkus-resteasy-reactive-jackson`
 * `io.quarkus:quarkus-jdbc-postgresql`
 --

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-sending-to-kafka.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-sending-to-kafka.adoc
@@ -60,7 +60,7 @@ The previous command adds the following dependency:
 ----
 <dependency>
   <groupId>io.quarkus</groupId>
-  <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+  <artifactId>quarkus-messaging-kafka</artifactId>
 </dependency>
 ----
 

--- a/quarkus-workshop-super-heroes/super-heroes/event-statistics/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/event-statistics/pom.xml
@@ -30,7 +30,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.0</quarkus.platform.version>
+    <quarkus.platform.version>3.14.2</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.2.2</surefire-plugin.version>
   </properties>
@@ -48,11 +48,11 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+      <artifactId>quarkus-messaging-kafka</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+      <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/pom.xml
@@ -30,7 +30,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.6.0</quarkus.platform.version>
+        <quarkus.platform.version>3.14.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.2</surefire-plugin.version>
         <quarkus.pact.version>1.3.0</quarkus.pact.version>
@@ -62,11 +62,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
+            <artifactId>quarkus-messaging-kafka</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -78,11 +78,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-heroes/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-heroes/pom.xml
@@ -30,7 +30,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.6.0</quarkus.platform.version>
+        <quarkus.platform.version>3.14.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.2</surefire-plugin.version>
         <quarkus.pact.version>1.3.0</quarkus.pact.version>
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-narration/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-narration/pom.xml
@@ -30,7 +30,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.0</quarkus.platform.version>
+    <quarkus.platform.version>3.14.2</quarkus.platform.version>
     <semantic-kernel.version>0.2.11-alpha</semantic-kernel.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.2.2</surefire-plugin.version>
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+      <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-villains/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-villains/pom.xml
@@ -29,7 +29,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.0</quarkus.platform.version>
+    <quarkus.platform.version>3.14.2</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.2.2</surefire-plugin.version>
   </properties>
@@ -47,7 +47,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+      <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-reactive</artifactId>
+      <artifactId>quarkus-rest</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/pom.xml
@@ -30,8 +30,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.6.0</quarkus.platform.version>
-        <quinoa.version>2.2.1</quinoa.version>
+        <quarkus.platform.version>3.14.2</quarkus.platform.version>
+        <quinoa.version>2.4.7</quinoa.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.2</surefire-plugin.version>
     </properties>
@@ -58,11 +58,11 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive</artifactId>
+            <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
- Update Quarkus dependencies from 3.6 ro 3.14
- Use new names of reactive extensions
- Update Quinoa to the latest verison (the old one failed with Quarkus 3.14)

Fixes https://github.com/quarkusio/quarkus-workshops/issues/587