### PR TITLE
Update REST Client Jackson dependency

### DIFF
--- a/quarkus-workshop-super-heroes/super-heroes/load-super-heroes/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/load-super-heroes/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
       <dependency>
           <groupId>io.quarkus</groupId>
-          <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+          <artifactId>quarkus-rest-client-jackson</artifactId>
       </dependency>
       <dependency>
           <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Quarkus 3.20 doesn't use relocations, we need change old dependencies names. 

/cc @cescoffier  @geoand