### PR TITLE
Fix typos and deprecated property in super-heroes workshop

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-quarkus/quarkus-lifecycle.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-quarkus/quarkus-lifecycle.adoc
@@ -77,7 +77,7 @@ In addition, Arc can detect and remove unused beans at runtime, saving memory.
 --
 
 With the application running in dev mode, open your browser to http://localhost:8084/q/dev/.
-In the ArC widget, you can see the number of beans that have been removed ("Removed Beans"), and if you click on the link, see the list.
+In the ArC widget, you can see the number of components that have been removed ("Removed components"), and if you click on the link, see the list of removed beans.
 If you click on the "Observers" link, you will see the two methods we added.
 In the "Fired Events" view, you can see which event has been fired and when.
 --

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-configuration.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-configuration.adoc
@@ -160,7 +160,7 @@ It's an amazing tool to manipulate JSON in the shell.
 More info on: https://stedolan.github.io/jq/
 ====
 
-Hey! Wait a minute! It you enabled continuous testing, Quarkus should have warned you:
+Hey! Wait a minute! If you enabled continuous testing, Quarkus should have warned you:
 
 [source,text]
 ----

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui-cors.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui-cors.adoc
@@ -50,7 +50,7 @@ So make sure you set the following properties on the:
 
 [source,properties]
 ----
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=/.*/
 ----
 --

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui-cors.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui-cors.adoc
@@ -13,7 +13,7 @@ It can be enabled in the Quarkus configuration file:
 
 [source,properties]
 ----
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 ----
 
 If the filter is enabled and an HTTP request is identified as cross-origin, the CORS policy and headers defined using the following properties will be applied before passing the request on to its actual target (servlet, JAX-RS resource, etc.):

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-provider-tests.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-provider-tests.adoc
@@ -57,7 +57,7 @@ Add the Pact dependency to the heroes service `pom.xml`:
 </dependency>
 ----
 
-We also add the https://quarkus.io/guides/hibernate-orm-panache#mocking[Panache Mock dependency], which allows us to which allows use Mockito to mock all provided static methods.
+We also add the https://quarkus.io/guides/hibernate-orm-panache#mocking[Panache Mock dependency], which allows us to use Mockito to mock all provided static methods.
 That will come in handy at various points in the provider testing.
 
 Create a `io/quarkus/workshop/superheroes/hero/HeroContractVerificationTest.java` class in the `rest-heroes` project.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-states.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-contract-testing/contract-testing-states.adoc
@@ -41,7 +41,7 @@ include::{projectdir}/rest-heroes/src/test/java/io/quarkus/workshop/superheroes/
 What's going on?
 The consumer expects a 404 if there are no heroes, but the provider is returning a 204.
 The reasoning from the consumer is that if a caller asks for a resource the server doesn't have, it should be a 404, the same way if a user types in an invalid URL into the browser.
-This is a more pure interpretation of REST than what was inplemented by the `HeroResource`.
+This is a more pure interpretation of REST than what was implemented by the `HeroResource`.
 
 There are arguments for both 404 (not found) and 204 (no content).
 Feel free to debate with your neighbour about which you prefer – but it doesn't really matter which is correct.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-receiving-from-kafka.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-receiving-from-kafka.adoc
@@ -88,7 +88,7 @@ Create the `io.quarkus.workshop.superheroes.statistics.Fight` class with the fol
 include::{projectdir}/event-statistics/src/main/java/io/quarkus/workshop/superheroes/statistics/Fight.java[]
 ----
 
-We also need to a deserializer that will receive the Kafka record and create the `Fight` instances.
+We also need to create a deserializer that will receive the Kafka record and create the `Fight` instances.
 Create the `io.quarkus.workshop.superheroes.statistics.FightDeserializer` class with the following content:
 
 [source,java]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-websocket.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-websocket.adoc
@@ -63,7 +63,7 @@ Finally, you need a UI to watch these live statistics.
 [example, role="cta"]
 --
 
-Replace the `META-INF/resources/index.html` file with the following content:
+Create the `src/main/resources/META-INF/resources/index.html` file with the following content:
 
 [source,html]
 ----

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/resources/application.properties
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/resources/application.properties
@@ -43,6 +43,6 @@ mp.messaging.outgoing.fights.value.serializer=io.quarkus.kafka.client.serializat
 
 # tag::adocCORS[]
 ## CORS
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 # end::adocCORS[]

--- a/quarkus-workshop-super-heroes/super-heroes/rest-heroes/src/main/resources/application.properties
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-heroes/src/main/resources/application.properties
@@ -14,6 +14,6 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 
 # tag::adocCORS[]
 ## CORS
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 # end::adocCORS[]

--- a/quarkus-workshop-super-heroes/super-heroes/rest-narration/src/main/resources/application.properties
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-narration/src/main/resources/application.properties
@@ -5,7 +5,7 @@ quarkus.http.port=8086
 quarkus.banner.path=banner.txt
 
 ## CORS
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 ## Logging configuration
 quarkus.log.category."com.microsoft.semantickernel".level=DEBUG

--- a/quarkus-workshop-super-heroes/super-heroes/rest-villains/src/main/resources/application.properties
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-villains/src/main/resources/application.properties
@@ -13,7 +13,7 @@ quarkus.log.console.level=INFO
 quarkus.log.console.darken=1
 
 ## CORS
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=*
 
 %prod.quarkus.datasource.username=superbad


### PR DESCRIPTION
I just finished doing the workshop and noticed some small errors:

- Fixed some small typos
- Replaced deprecated `quarkus.http.cors` property with `quarkus.http.cors.enabled`
- In the messaging websocket chapter it said "Replace the META-INF/resources/index.html file contents", even though this file has never been created before, changed it to "Create the ..."
- In the Dev UI's ArC widget there is only "Removed components" not  "Removed beans" directly, when you click on it then you have the "Removed beans" list
![image](https://github.com/user-attachments/assets/61e1251e-d779-456e-b5f3-49e04c87f145)


Just wanna say I really enjoyed the workshop, it includes a lot of important use-cases with very easy to follow instructions and useful hints for new developers 🙂