### PR TITLE
Fix annotationProcessorPath resolution for productized builds

### DIFF
--- a/quarkus-workshop-super-heroes/super-heroes/extension-version/deployment/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/extension-version/deployment/pom.xml
@@ -30,6 +30,7 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
+          <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
           <annotationProcessorPaths>
             <path>
               <groupId>io.quarkus</groupId>

--- a/quarkus-workshop-super-heroes/super-heroes/extension-version/runtime/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/extension-version/runtime/pom.xml
@@ -36,6 +36,7 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
+          <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
           <annotationProcessorPaths>
             <path>
               <groupId>io.quarkus</groupId>


### PR DESCRIPTION
## Summary                                                                                                                                            
                                                                                    
 - Enable `annotationProcessorPathsUseDepMgmt` in extension-version runtime and deployment modules   
Without this, `snakeyaml:2.5.0.redhat-00001` is resolved from `jackson-dataformat-yaml`  POM instead of using the BOM-managed 2.4.0, causing build failures when the artifact is absent from maven repository.