### PR TITLE
Do not do trigger preview CI for merges to main

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,6 +5,8 @@ on:
     workflows: [ "Build" ]
     types:
       - completed
+    branches-ignore:
+      - "main"
 
 jobs:
   preview:


### PR DESCRIPTION
I notice we have a lot of clutter of skipped workflows for previews when we merge PRs. We have a guard on the steps, but it would be better to guard the whole workflow. 

I think `branches-ignore` does what we need, and applies to workflow completed triggers: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_runbranchesbranches-ignore

<img width="655" height="53" alt="image" src="https://github.com/user-attachments/assets/3f2ea078-a9de-425b-9f09-2967a5eed95c" />

(We also have a bunch of queues preview jobs, which I can't explain yet, but that's a separate problem.)