### PR TITLE
Add necessary permissions for generate zips job to push to the repo

### DIFF
--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - 'quarkus-workshop-super-heroes/docs/**'
       - 'quarkus-workshop-super-heroes/dist/**'
+
+permissions:
+  contents: write
+
 jobs:
   build_java17:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The generate zips job has been failing since April with 

```
Run git config --global user.name 'Github Actions'
[main f62ea06] Automated zip generation
3 files changed, 0 insertions(+), 0 deletions(-)
remote: Permission to quarkusio/quarkus-workshops.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/quarkusio/quarkus-workshops/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```