### PR TITLE
Fix queued preview workflows: Use latest ubuntu for flexibility

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact


### PR DESCRIPTION
The preview workflows were queueing indefinitely. The problem was they specified a ubuntu-20 runner, which isn't available anymore.