### PR TITLE
Use distinct job for deploy steps to avoid PRs failing with branch protection issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,6 @@ jobs:
   publication:
     needs: [ docs, build_java17 ]
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download default site
         uses: actions/download-artifact@v8
@@ -108,6 +105,9 @@ jobs:
     if: "github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
     needs: [ publication ]
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download Built site
         uses: actions/download-artifact@v8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,12 +104,20 @@ jobs:
           name: site
           path: ./target/site
           retention-days: 3
+  deploy:
+    if: "github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
+    needs: [ publication ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Built site
+        uses: actions/download-artifact@v8
+        with:
+          name: site
+          path: site
       - name: Upload Pages artifact
-        if: "github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./target/site
+          path: site
       - name: Deploy to GitHub Pages
-        if: "github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Since changing the settings to use Actions for GitHub pages (which is necessary for the non-third-party actions), PR CIs are failing with errors like 

```
Branch "refs/pull/619/merge" is not allowed to deploy to github-pages due to environment protection rules.
```

It's surprising since there is a guard, but the guard is at the step level. Checking what other quarkusio sites do, they seem to have a job dedicated to site-publishing, and put the guard at the site level. Let's try that.