### PR TITLE
Fix unterminated conditional block to resolve mostly-empty workshop contents

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-graalvm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-graalvm.adoc
@@ -51,6 +51,7 @@ Version {graalvm-version} is required.
 Select the {jdk-version} version.
 
 Follow the https://www.graalvm.org/jdk{graalvm-version}/docs[installation instructions].
+endif::[]
 
 ifdef::use-mac[]
 === Listing GraalVM Versions


### PR DESCRIPTION
#612 (and specifically https://github.com/quarkusio/quarkus-workshops/commit/e35a9b7a3e8d1a93aeba4dcba63211a7306146bf#diff-a2f887e8add6b4b0d9085cd10dd46252e4b272e4632e795dc4e282bf1aa6c9c8L52) introduced a syntax error. We didn't catch it because preview jobs weren't running, and we don't have automated tests for the html being basically complete. I've fixed one preview issue but need to fix a second, and I'll add some tests to try and prevent this kind of regression in future.