### PR TITLE
Improve version consistency of GraalVM instructions

### DIFF
--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -48,6 +48,7 @@ The default build will take around 50m.
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>3.33.1</quarkus.platform.version>
         <quarkus.pact.version>1.6.0</quarkus.pact.version>
+        <graalvm.version>25.0.2</graalvm.version>
         <quarkus-langchain4j.version>1.9.2</quarkus-langchain4j.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
@@ -95,6 +96,11 @@ The default build will take around 50m.
             <groupId>io.quarkiverse.pact</groupId>
             <artifactId>quarkus-pact-provider</artifactId>
             <version>${quarkus.pact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+            <version>${graalvm.version}</version>
         </dependency>
     </dependencies>
 
@@ -152,7 +158,7 @@ The default build will take around 50m.
                             <give-solution>true</give-solution>
                             <jdk-version>${maven.compiler.source}</jdk-version>
                             <!-- NOTE! Any version listed here should have an entry in the dependencies, so that dependabot keeps docs in sync with implementation -->
-                            <graalvm-version>21</graalvm-version>
+                            <graalvm-version>${graalvm.version}</graalvm-version>
                             <maven-version>3.9.x</maven-version>
                             <quarkus-version>${quarkus.platform.version}</quarkus-version>
                             <compiler-plugin-version>${compiler-plugin.version}</compiler-plugin-version>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-graalvm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-installing-graalvm.adoc
@@ -30,11 +30,6 @@ endif::use-linux[]
 ifdef::use-mac[]
 On macOS X there are several ways to install GraalVM.
 But using https://sdkman.io/[SDKMAN!] is the preferred option, as it allows you to easily switch between different versions of GraalVM if needed.
-
-[source,shell]
-----
-xcode-select --install
-----
 endif::use-mac[]
 
 ifdef::use-windows[]
@@ -45,16 +40,24 @@ endif::use-windows[]
 == Installing GraalVM
 
 ifndef::use-mac[]
-GraalVM is installed from the GraalVM project.footnote:[GraalVM Download https://github.com/graalvm/graalvm-ce-builds/releases].
+GraalVM is installed from the GraalVM project.footnote:[GraalVM Download https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-{graalvm-version}].
 
 Version {graalvm-version} is required.
 Select the {jdk-version} version.
 
-Follow the https://www.graalvm.org/jdk{graalvm-version}/docs[installation instructions].
-endif::[]
+Follow the installation instructions:
+
+ifdef::use-linux[]
+- Linux - https://www.graalvm.org/{graalvm-version}/docs/getting-started/linux/
+endif::use-linux[]
+ifdef::use-windows[]
+- Windows - https://www.graalvm.org/{graalvm-version}/docs/getting-started/windows/
+endif::use-windows[]
+endif::use-mac[]
+
 
 ifdef::use-mac[]
-=== Listing GraalVM Versions
+=== Listing GraalVM Versions with SDKMan
 
 First of all, check if you already have the GraalVM Candidates installed on your machine.
 To list the available versions of GraalVM, use the SDKMAN! `list java` command.
@@ -120,7 +123,7 @@ You should get something like:
 
 [source,shell]
 ----
-native-image 21.0.2 2024-01-16
+native-image ${graalvm-version} 2024-01-16
 GraalVM Runtime Environment GraalVM CE 21.0.2+13.1 (build 21.0.2+13-jvmci-23.1-b30)
 Substrate VM GraalVM CE 21.0.2+13.1 (build 21.0.2+13, serial gc)
 ----


### PR DESCRIPTION
We still show a specific GraalVM version at several points in the docs. For example:

<img width="290" height="139" alt="image" src="https://github.com/user-attachments/assets/d96446c6-fd32-440f-8915-8d2095e9e47e" />

We would like this version to be (a) consistent with what people are likely to install and (b) managed by dependabot and (c) the version we test the workshop with. 

For most of the versions in our docs, it's pretty easy to have them managed by dependabot. It's a bit harder for GraalVM, but we can do (a) and (b) in a slightly hacky way by having the docs depend on the GraalVM SDK. To do (c) is harder, because the native installation wouldn't usually be triggered by a pom, and at the moment we don't test any native execution at all (except in the default container). I think it's worth doing (a) and (b) even if we can't do (c) yet.

While I was reviewing the live docs, I noticed we also have some strange orphan text which I think is no longer necessary:

<img width="640" height="134" alt="image" src="https://github.com/user-attachments/assets/03e94b6d-e818-4e39-a32f-82efc726e239" />

It's hard to say for sure if those instructions are needed since few of us have a clean machine with no xcode to test on.

When we change things in conditional includes, it's worth checking the local `spine.html`, because the default docs have _all_ of linux, windows, and mac set to true, and than can create some funny flows.