### PR TITLE
Add permissions block to preview workflow so it can download the build artifact

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,10 @@ on:
     branches-ignore:
       - "main"
 
+permissions:
+  actions: read
+  pull-requests: write
+
 jobs:
   preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This was an annoying one. It's another casualty of tightening the workflow permissions. The preview workflows (once I fixed all the other problems) are failing with an error about how the PR build didn't create a `site` artifact. This is a totally misleading message, because the problem is actually that the PR workflow doesn't have permission to see it. 

The workflow won't be fixed until this merges, so this PR will fail with the same error.