### PR TITLE
Test generated documentation for basic "has a decent size", etc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Playwright
         run: |
           cd quarkus-workshop-super-heroes/docs
-          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps chromium"
+          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.classpathScope=test -D exec.args="install --with-deps chromium"
       - name: Build and test site
         run: |
           cd quarkus-workshop-super-heroes/docs
@@ -123,7 +123,7 @@ jobs:
       - name: Install Playwright
         run: |
           cd quarkus-workshop-super-heroes/docs
-          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps chromium"
+          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.classpathScope=test -D exec.args="install --with-deps chromium"
       - name: Run documentation tests
         run: |
           cd quarkus-workshop-super-heroes/docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,9 +100,39 @@ jobs:
           name: site
           path: ./target/site
           retention-days: 3
+  test-docs:
+    needs: [ publication ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Download assembled site
+        uses: actions/download-artifact@v8
+        with:
+          name: site
+          path: target/site
+      - name: Install Playwright
+        run: |
+          cd quarkus-workshop-super-heroes/docs
+          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps chromium"
+      - name: Run documentation tests
+        run: |
+          cd quarkus-workshop-super-heroes/docs
+          mvn test -Ddocs.base.path=../../target/site/super-heroes
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results
+          path: quarkus-workshop-super-heroes/docs/target/surefire-reports
+          retention-days: 7
   deploy:
     if: "github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
-    needs: [ publication ]
+    needs: [ publication, test-docs ]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,18 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-      - name: Site generation
+      - name: Site generation prep
         run: |
           sudo apt-get install graphviz
           
           export BASE_URL=`curl -Ls -o /dev/null -w %{url_effective} -I ${GITHUB_REPOSITORY_OWNER}.github.io`
-
-          cd quarkus-workshop-super-heroes/docs      
+      - name: Install Playwright
+        run: |
+          cd quarkus-workshop-super-heroes/docs
+          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.args="install --with-deps chromium"
+      - name: Build and test site
+        run: |
+          cd quarkus-workshop-super-heroes/docs
           mvn package -Dos=${{ matrix.os }}
       - name: Publishing fragment
         uses: actions/upload-artifact@v7

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -37,6 +37,8 @@ The default build will take around 50m.
         <version.asciidoctorj>2.5.10</version.asciidoctorj>
         <version.asciidoctorj.pdf>2.3.9</version.asciidoctorj.pdf>
         <version.asciidoctorj.diagram>2.2.13</version.asciidoctorj.diagram>
+        <version.playwright>1.48.0</version.playwright>
+        <version.junit>5.11.4</version.junit>
         <!-- If building docs locally and urls matter, set environment variables for these values -->
         <github.raw>https://raw.githubusercontent.com/${env.GITHUB_REPOSITORY}/${env.GITHUB_REF}/quarkus-workshop-super-heroes</github.raw>
         <github.repo>${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}</github.repo>
@@ -95,6 +97,31 @@ The default build will take around 50m.
             <groupId>io.quarkiverse.pact</groupId>
             <artifactId>quarkus-pact-provider</artifactId>
             <version>${quarkus.pact.version}</version>
+        </dependency>
+        <!-- Playwright for documentation testing -->
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>${version.playwright}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -165,6 +192,30 @@ The default build will take around 50m.
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>dev.jbang</groupId>
                 <artifactId>jbang-maven-plugin</artifactId>

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTest.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.*;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTest.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTest.java
@@ -1,0 +1,167 @@
+package io.quarkus.workshop.docs;
+
+import com.microsoft.playwright.*;
+import org.junit.jupiter.api.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DocumentationTest extends DocumentationTestBase {
+
+    @Test
+    @DisplayName("Main spine.html file should exist")
+    void testSpineFileExists() {
+        Path spineFile = Paths.get(DOCS_BASE_PATH, SPINE_HTML);
+        assertTrue(Files.exists(spineFile), "spine.html should exist at " + spineFile);
+    }
+
+    @Test
+    @DisplayName("Main spine.html should load without errors")
+    void testSpineLoadsSuccessfully() {
+        String fileUrl = "file://" + Paths.get(DOCS_BASE_PATH, SPINE_HTML).toAbsolutePath();
+
+        Response response = page.navigate(fileUrl);
+        assertNotNull(response, "Page should load");
+        assertTrue(response.ok() || response.status() == 0,
+            "Page should load successfully (status: " + response.status() + ")");
+    }
+
+    @Test
+    @DisplayName("Main spine.html should have proper title")
+    void testSpineHasTitle() {
+        navigateToSpine();
+
+        String title = page.title();
+        assertNotNull(title, "Page should have a title");
+        assertFalse(title.isEmpty(), "Title should not be empty");
+        assertTrue(title.toLowerCase().contains("quarkus") || title.toLowerCase().contains("workshop"),
+            "Title should contain 'Quarkus' or 'Workshop', but was: " + title);
+    }
+
+    @Test
+    @DisplayName("Main spine.html should have table of contents")
+    void testSpineHasTableOfContents() {
+        navigateToSpine();
+
+        Locator toc = page.locator("#toc, .toc, nav");
+        assertTrue(toc.count() > 0, "Page should have a table of contents");
+    }
+
+    @Test
+    @DisplayName("Main spine.html should have main content sections")
+    void testSpineHasMainSections() {
+        navigateToSpine();
+
+        int h2Count = page.locator("h2").count();
+        assertTrue(h2Count >= 10,
+            "Full spine should have at least 10 top-level sections, but found " + h2Count);
+
+        int sectionCount = page.locator(".sect1").count();
+        assertTrue(sectionCount >= 10,
+            "Full spine should have at least 10 sect1 blocks, but found " + sectionCount);
+    }
+
+    @Test
+    @DisplayName("Main spine.html should have code blocks")
+    void testSpineHasCodeBlocks() {
+        navigateToSpine();
+
+        Locator codeBlocks = page.locator("pre code, .listingblock, .code");
+        assertTrue(codeBlocks.count() > 0, "Page should have code blocks");
+    }
+
+    @Test
+    @DisplayName("Main spine.html internal links should work")
+    void testSpineInternalLinksWork() {
+        navigateToSpine();
+
+        Set<String> brokenLinks = findBrokenInternalLinks();
+
+        assertTrue(brokenLinks.isEmpty(),
+            "Found broken internal links: " + String.join(", ", brokenLinks));
+    }
+
+    @Test
+    @DisplayName("Main spine.html should not have broken image references")
+    void testSpineImagesLoad() {
+        navigateToSpine();
+
+        Set<String> brokenImages = findBrokenImages();
+
+        assertTrue(brokenImages.isEmpty(),
+            "Found broken images: " + String.join(", ", brokenImages));
+    }
+
+    @Test
+    @DisplayName("Main spine.html external links should be valid URLs")
+    void testSpineExternalLinksAreValid() {
+        navigateToSpine();
+
+        Locator externalLinks = page.locator("a[href^='http://'], a[href^='https://']");
+        int linkCount = externalLinks.count();
+
+        Set<String> invalidUrls = new HashSet<>();
+
+        for (int i = 0; i < linkCount; i++) {
+            String href = externalLinks.nth(i).getAttribute("href");
+            if (href != null && !isValidUrl(href)) {
+                invalidUrls.add(href);
+            }
+        }
+
+        assertTrue(invalidUrls.isEmpty(),
+            "Found invalid external URLs: " + String.join(", ", invalidUrls));
+    }
+
+    @Test
+    @DisplayName("Main spine.html should have proper heading hierarchy")
+    void testSpineHeadingHierarchy() {
+        navigateToSpine();
+
+        Locator h1 = page.locator("h1");
+        Locator h2 = page.locator("h2");
+        Locator h3 = page.locator("h3");
+
+        int h1Count = h1.count();
+        int h2Count = h2.count();
+        int h3Count = h3.count();
+
+        assertTrue(h1Count > 0, "Document should have at least one h1");
+
+        if (h3Count > 0) {
+            assertTrue(h2Count > 0, "If h3 exists, h2 should also exist");
+        }
+    }
+
+    @Test
+    @DisplayName("Main spine.html should contain key workshop sections")
+    void testSpineHasKeyContent() {
+        navigateToSpine();
+
+        String pageContent = page.content();
+
+        assertTrue(pageContent.contains("Villain Microservice") ||
+                   pageContent.contains("Villain microservice") ||
+                   pageContent.contains("villain microservice"),
+            "Page should contain 'Villain Microservice' section");
+
+        assertTrue(pageContent.contains("Hero Microservice") ||
+                   pageContent.contains("Hero microservice") ||
+                   pageContent.contains("hero microservice"),
+            "Page should contain 'Hero Microservice' section");
+
+        assertTrue(pageContent.contains("Fight Microservice") ||
+                   pageContent.contains("Fight microservice") ||
+                   pageContent.contains("fight microservice"),
+            "Page should contain 'Fight Microservice' section");
+    }
+
+    private void navigateToSpine() {
+        navigateTo(Paths.get(DOCS_BASE_PATH, SPINE_HTML));
+    }
+}

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTest.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTest.java
@@ -3,6 +3,7 @@ package io.quarkus.workshop.docs;
 import com.microsoft.playwright.*;
 import org.junit.jupiter.api.*;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -16,14 +17,14 @@ public class DocumentationTest extends DocumentationTestBase {
     @Test
     @DisplayName("Main spine.html file should exist")
     void testSpineFileExists() {
-        Path spineFile = Paths.get(DOCS_BASE_PATH, SPINE_HTML);
+        Path spineFile = new File(DOCS_BASE_PATH, SPINE_HTML).toPath();
         assertTrue(Files.exists(spineFile), "spine.html should exist at " + spineFile);
     }
 
     @Test
     @DisplayName("Main spine.html should load without errors")
     void testSpineLoadsSuccessfully() {
-        String fileUrl = "file://" + Paths.get(DOCS_BASE_PATH, SPINE_HTML).toAbsolutePath();
+        String fileUrl = "file://" + new File(DOCS_BASE_PATH, SPINE_HTML).toPath().toAbsolutePath();
 
         Response response = page.navigate(fileUrl);
         assertNotNull(response, "Page should load");
@@ -162,6 +163,6 @@ public class DocumentationTest extends DocumentationTestBase {
     }
 
     private void navigateToSpine() {
-        navigateTo(Paths.get(DOCS_BASE_PATH, SPINE_HTML));
+        navigateTo(new File(DOCS_BASE_PATH, SPINE_HTML).toPath());
     }
 }

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTestBase.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTestBase.java
@@ -5,6 +5,7 @@ import com.microsoft.playwright.options.BoundingBox;
 import com.microsoft.playwright.options.LoadState;
 import org.junit.jupiter.api.*;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
@@ -17,7 +18,7 @@ public abstract class DocumentationTestBase {
     protected BrowserContext context;
     protected Page page;
 
-    protected static final String DOCS_BASE_PATH = System.getProperty("docs.base.path", "target/generated-asciidoc/");
+    protected static final File DOCS_BASE_PATH = new File(System.getProperty("docs.base.path", "target/generated-asciidoc/"));
     protected static final String SPINE_HTML = "spine.html";
 
     private static final Pattern URL_PATTERN = Pattern.compile(

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTestBase.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/DocumentationTestBase.java
@@ -1,0 +1,117 @@
+package io.quarkus.workshop.docs;
+
+import com.microsoft.playwright.*;
+import com.microsoft.playwright.options.BoundingBox;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.*;
+
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public abstract class DocumentationTestBase {
+
+    protected static Playwright playwright;
+    protected static Browser browser;
+    protected BrowserContext context;
+    protected Page page;
+
+    protected static final String DOCS_BASE_PATH = System.getProperty("docs.base.path", "target/generated-asciidoc/");
+    protected static final String SPINE_HTML = "spine.html";
+
+    private static final Pattern URL_PATTERN = Pattern.compile(
+        "^(https?://)([\\w.-]+)(:[0-9]+)?(/.*)?$",
+        Pattern.CASE_INSENSITIVE
+    );
+
+    @BeforeAll
+    static void launchBrowser() {
+        playwright = Playwright.create();
+        browser = playwright.chromium().launch(new BrowserType.LaunchOptions().setHeadless(true));
+    }
+
+    @AfterAll
+    static void closeBrowser() {
+        if (browser != null) {
+            browser.close();
+        }
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    @BeforeEach
+    void createContextAndPage() {
+        context = browser.newContext();
+        page = context.newPage();
+    }
+
+    @AfterEach
+    void closeContext() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    protected void navigateTo(Path htmlFile) {
+        String fileUrl = "file://" + htmlFile.toAbsolutePath();
+        page.navigate(fileUrl);
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+    }
+
+    protected Set<String> findBrokenInternalLinks() {
+        Locator internalLinks = page.locator("a[href^='#']");
+        int linkCount = internalLinks.count();
+        Set<String> brokenLinks = new HashSet<>();
+
+        for (int i = 0; i < linkCount; i++) {
+            String href = internalLinks.nth(i).getAttribute("href");
+            if (href != null && !href.isEmpty()) {
+                String targetId = href.substring(1);
+                // Use attribute selector — bare #id breaks on AsciiDoc IDs containing dots or colons
+                Locator target = page.locator("[id='" + escapeAttrValue(targetId) + "']");
+                if (target.count() == 0) {
+                    brokenLinks.add(href);
+                }
+            }
+        }
+
+        return brokenLinks;
+    }
+
+    protected Set<String> findBrokenImages() {
+        Locator images = page.locator("img");
+        int imageCount = images.count();
+        Set<String> brokenImages = new HashSet<>();
+
+        for (int i = 0; i < imageCount; i++) {
+            Locator img = images.nth(i);
+            String src = img.getAttribute("src");
+
+            if (src != null && !src.isEmpty()) {
+                try {
+                    BoundingBox box = img.boundingBox();
+                    if (box == null || (box.width == 0 && box.height == 0)) {
+                        Object naturalWidth = img.evaluate("img => img.naturalWidth");
+                        if (naturalWidth == null || ((Number) naturalWidth).intValue() == 0) {
+                            brokenImages.add(src);
+                        }
+                    }
+                } catch (Exception e) {
+                    brokenImages.add(src + " (error: " + e.getMessage() + ")");
+                }
+            }
+        }
+
+        return brokenImages;
+    }
+
+    protected boolean isValidUrl(String url) {
+        return URL_PATTERN.matcher(url).matches();
+    }
+
+    private String escapeAttrValue(String value) {
+        return value.replace("\\", "\\\\").replace("'", "\\'");
+    }
+}

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/VariantsTest.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/VariantsTest.java
@@ -1,0 +1,173 @@
+package io.quarkus.workshop.docs;
+
+import com.microsoft.playwright.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+/**
+ * Tests for documentation variants.
+ * These tests can only be run after variants are generated, which is time-consuming.
+ * Tests are skipped when the variants directory does not exist.
+ */
+public class VariantsTest extends DocumentationTestBase {
+
+    private static final String VARIANTS_PATH = DOCS_BASE_PATH + "/variants/";
+
+    static Stream<Path> variantProvider() throws IOException {
+        Path variantsDir = Paths.get(VARIANTS_PATH);
+
+        if (!Files.exists(variantsDir)) {
+            return Stream.empty();
+        }
+
+        List<Path> variants = new ArrayList<>();
+
+        try (Stream<Path> paths = Files.walk(variantsDir, 2)) {
+            paths.filter(Files::isDirectory)
+                 .filter(p -> !p.equals(variantsDir))
+                 .forEach(dir -> {
+                     Path spineFile = dir.resolve(SPINE_HTML);
+                     if (Files.exists(spineFile)) {
+                         variants.add(spineFile);
+                     }
+                 });
+        }
+
+        return variants.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("variantProvider")
+    @DisplayName("Each variant should load without errors")
+    void testVariantLoadsSuccessfully(Path variantFile) {
+        String fileUrl = "file://" + variantFile.toAbsolutePath();
+
+        Response response = page.navigate(fileUrl);
+        assertNotNull(response, "Variant page should load: " + variantFile);
+        assertTrue(response.ok() || response.status() == 0,
+            "Variant page should load successfully: " + variantFile + " (status: " + response.status() + ")");
+    }
+
+    @ParameterizedTest
+    @MethodSource("variantProvider")
+    @DisplayName("Each variant should have proper title")
+    void testVariantHasTitle(Path variantFile) {
+        navigateTo(variantFile);
+
+        String title = page.title();
+        assertNotNull(title, "Variant should have a title: " + variantFile);
+        assertFalse(title.isEmpty(), "Variant title should not be empty: " + variantFile);
+        assertTrue(title.toLowerCase().contains("quarkus") || title.toLowerCase().contains("workshop"),
+            "Variant title should contain 'Quarkus' or 'Workshop': " + variantFile + ", but was: " + title);
+    }
+
+    @ParameterizedTest
+    @MethodSource("variantProvider")
+    @DisplayName("Each variant should have table of contents")
+    void testVariantHasTableOfContents(Path variantFile) {
+        navigateTo(variantFile);
+
+        Locator toc = page.locator("#toc, .toc, nav");
+        assertTrue(toc.count() > 0,
+            "Variant should have a table of contents: " + variantFile);
+    }
+
+    @ParameterizedTest
+    @MethodSource("variantProvider")
+    @DisplayName("Each variant should have main content sections")
+    void testVariantHasMainSections(Path variantFile) {
+        navigateTo(variantFile);
+
+        int h2Count = page.locator("h2").count();
+        assertTrue(h2Count >= 5,
+            "Variant " + variantFile.getFileName() + " should have at least 5 top-level sections, but found " + h2Count);
+
+        int sectionCount = page.locator(".sect1").count();
+        assertTrue(sectionCount >= 5,
+            "Variant " + variantFile.getFileName() + " should have at least 5 sect1 blocks, but found " + sectionCount);
+    }
+
+    @ParameterizedTest
+    @MethodSource("variantProvider")
+    @DisplayName("Each variant internal links should work")
+    void testVariantInternalLinksWork(Path variantFile) {
+        navigateTo(variantFile);
+
+        Set<String> brokenLinks = findBrokenInternalLinks();
+
+        assertTrue(brokenLinks.isEmpty(),
+            "Variant " + variantFile.getFileName() + " has broken internal links: " +
+            String.join(", ", brokenLinks));
+    }
+
+    @ParameterizedTest
+    @MethodSource("variantProvider")
+    @DisplayName("Each variant should not have broken image references")
+    void testVariantImagesLoad(Path variantFile) {
+        navigateTo(variantFile);
+
+        Set<String> brokenImages = findBrokenImages();
+
+        assertTrue(brokenImages.isEmpty(),
+            "Variant " + variantFile.getFileName() + " has broken images: " +
+            String.join(", ", brokenImages));
+    }
+
+    @ParameterizedTest
+    @MethodSource("variantProvider")
+    @DisplayName("Each variant should have code blocks")
+    void testVariantHasCodeBlocks(Path variantFile) {
+        navigateTo(variantFile);
+
+        Locator codeBlocks = page.locator("pre code, .listingblock, .code");
+        assertTrue(codeBlocks.count() > 0,
+            "Variant should have code blocks: " + variantFile);
+    }
+
+    @Test
+    @DisplayName("Sample of variants should have different content based on flags")
+    void testVariantsHaveDifferentContent() throws IOException {
+        Path variantsDir = Paths.get(VARIANTS_PATH);
+        assumeTrue(Files.exists(variantsDir), "Variants directory not generated yet");
+
+        List<Path> variantFiles = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(variantsDir, 2)) {
+            paths.filter(Files::isDirectory)
+                 .filter(p -> !p.equals(variantsDir))
+                 .limit(5)
+                 .forEach(dir -> {
+                     Path spineFile = dir.resolve(SPINE_HTML);
+                     if (Files.exists(spineFile)) {
+                         variantFiles.add(spineFile);
+                     }
+                 });
+        }
+
+        assumeTrue(variantFiles.size() >= 2, "Need at least 2 variants to compare");
+
+        Set<Long> fileSizes = new HashSet<>();
+        for (Path variant : variantFiles) {
+            fileSizes.add(Files.size(variant));
+        }
+
+        if (variantFiles.size() > 2) {
+            assertTrue(fileSizes.size() > 1,
+                "Variants should have different content sizes (found " + fileSizes.size() +
+                " unique sizes from " + variantFiles.size() + " variants)");
+        }
+    }
+}

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/VariantsTest.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/VariantsTest.java
@@ -27,12 +27,17 @@ public class VariantsTest extends DocumentationTestBase {
 
     private static final File VARIANTS_PATH = new File(DOCS_BASE_PATH,"variants");
 
+    @BeforeAll
+    static void checkVariantsExist() {
+        assumeTrue(VARIANTS_PATH.exists(),
+            "Variants directory does not exist: " + VARIANTS_PATH + ". Skipping variant tests.");
+    }
+
     static Stream<Path> variantProvider() throws IOException {
         Path variantsDir = VARIANTS_PATH.toPath();
 
-        if (!Files.exists(variantsDir)) {
-            throw new IllegalStateException(String.format("The variants directory, %s, does not exist.", variantsDir));
-        }
+        assumeTrue(Files.exists(variantsDir),
+            String.format("The variants directory, %s, does not exist.", variantsDir));
 
         List<Path> variants = new ArrayList<>();
 

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/VariantsTest.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/VariantsTest.java
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -25,13 +25,13 @@ import static org.junit.jupiter.api.Assumptions.*;
  */
 public class VariantsTest extends DocumentationTestBase {
 
-    private static final String VARIANTS_PATH = DOCS_BASE_PATH + "/variants/";
+    private static final File VARIANTS_PATH = new File(DOCS_BASE_PATH,"variants");
 
     static Stream<Path> variantProvider() throws IOException {
-        Path variantsDir = Paths.get(VARIANTS_PATH);
+        Path variantsDir = VARIANTS_PATH.toPath();
 
         if (!Files.exists(variantsDir)) {
-            return Stream.empty();
+            throw new IllegalStateException(String.format("The variants directory, %s, does not exist.", variantsDir));
         }
 
         List<Path> variants = new ArrayList<>();
@@ -141,7 +141,7 @@ public class VariantsTest extends DocumentationTestBase {
     @Test
     @DisplayName("Sample of variants should have different content based on flags")
     void testVariantsHaveDifferentContent() throws IOException {
-        Path variantsDir = Paths.get(VARIANTS_PATH);
+        Path variantsDir = VARIANTS_PATH.toPath();
         assumeTrue(Files.exists(variantsDir), "Variants directory not generated yet");
 
         List<Path> variantFiles = new ArrayList<>();


### PR DESCRIPTION
We don't want to end up in a situation where a change to the asciidoc trashes the workshop and we don't notice, so I've added some basic tests of the generated html. This was written by Bob and then reviewed + Improved by Claude. 

I’ve run this for the quick build and the verrrry slow all-variants build. I’ve checked that reverting #633 makes the test fail, and I’ve also checked that introducing a broken link makes the test fail. Getting the second situation to cause a test failure caused some head-scratching for my agent. (“I broke a link, why is my test passing? Oh, because I WROTE A DUMB TEST. I fixed my test to be less dumb, why is the test still passing?”:) 

I’ll do another PR for being stricter and failing the build when asciidoc complains, but there are some asciidoc problems that are proving tricky to fix. 

With #633 reverted, the tests actually fail in three ways, so that should be good insurance against future problems:

  1. testSpineHasMainSections — "Full spine should have at least 10 top-level sections, but found 1" — the unterminated conditional swallowed most
  of the document
  2. testSpineInternalLinksWork — broken links to #appendix-installing-maven, #appendix-installing-curl (sections that got swallowed)
  3. testSpineHasKeyContent — "Hero Microservice" section is missing (also swallowed)
  
  Previews are still broken (grrrrr), but as this is test-only, it should be ok to do without previews.