### PR TITLE
Fix preview (again)  by passing github-token to download-artifact

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Download PR Artifact
         uses: actions/download-artifact@v8
         with:
+          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
           name: site
       - name: Store PR id as variable


### PR DESCRIPTION
More fallout from switching away from the third-party download action in the preview workflow. To download from another workflow, we need to pass a git token property.

Should have copied from a working example instead of just swapping workflows, with hindsight.