### PR TITLE
Minor preview improvements: Lock surge version, improve domain

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,7 @@ jobs:
           rm -f pr-id.txt
       - name: Publishing to surge for preview
         id: deploy
-        run: npx surge ./ --domain https://quarkiverse-quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: npx surge@0.23.1 ./ --domain quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment on success
         uses: quarkusio/action-helpers@main
         with:


### PR DESCRIPTION
I don't think either of these will fix the permissions failure, but they're probably worth doing anyway. 

- Following the model of Quarkus repo, I've locked the surge version
- @gastaldi rightly points out that 'quarkiverse' shouldn't be in the domain name, so I've fixed that

We have an org-level surge key, so it's a bit of a mystery why it's not working.