### PR TITLE
Trim preview site for Surge size limit

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,11 @@ jobs:
         run: |
           echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
           rm -f pr-id.txt
+      - name: Trim site for preview
+        run: |
+          rm -rf super-heroes/linux super-heroes/windows
+          cd super-heroes/variants
+          rm -rf os-linux-* os-windows-*
       - name: Publishing to surge for preview
         id: deploy
         run: npx surge ./ --domain https://quarkiverse-quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
Resolves #443 

We're now back to *old* preview issues, hurray!

As with the main Quarkus site, we need to delete content before doing the preview. 

- The assembled preview site is ~1 GB, exceeding Surge's size limit and causing "application too large" deploy failures
- Adds a trim step before Surge publish that removes the linux and windows OS directories and their OS-specific variants
- Keeps mac and os-all variants (~430 MB total), sufficient for reviewing content changes
