### PR TITLE
Also remove mac per-OS directory to further reduce preview size

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,9 +23,10 @@ jobs:
           rm -f pr-id.txt
       - name: Trim site for preview
         run: |
-          rm -rf super-heroes/linux super-heroes/windows
+          rm -rf super-heroes/linux super-heroes/mac super-heroes/windows
           cd super-heroes/variants
           rm -rf os-linux-* os-windows-*
+          du -sh ..
       - name: Publishing to surge for preview
         id: deploy
         run: npx surge ./ --domain https://quarkiverse-quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
The previous trim (~430 MB) still exceeded Surge's limit. This is surprising, because I thought it was 500MB, but whatever. Removing the super-heroes/mac/ directory (a full 151 MB site copy) brings the preview to ~290 MB while keeping os-all and os-mac variants accessible. Added du output for debugging.