### PR TITLE
Correct surge links in teardown and comments

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Teardown surge preview
         id: deploy
-        run: npx surge teardown https://quarkiverse-quarkus-workshops-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
+        run: npx surge teardown https://quarkus-workshops-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
       - name: Update PR status comment
         uses: quarkusio/action-helpers@main
         if: env.NOT_TORNDOWN != 'true'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,7 +43,7 @@ jobs:
           action: maintain-one-comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkiverse-quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
           body-marker: '<!-- Sticky Pull Request Comment -->'
           pr-number: ${{ steps.pr.outputs.id }}
       - name: Update PR status comment on failure


### PR DESCRIPTION
Preview is soooo close to working again. 

<img width="615" height="143" alt="image" src="https://github.com/user-attachments/assets/aedd2c43-3094-40ef-b46d-3dd7c230401a" />


But when I updated the domain, I forgot to update the comment, and also the teardown.