### PR TITLE
Be strict in asciidoc build to avoid green builds for dead sites

### DIFF
--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -186,7 +186,15 @@ The default build will take around 50m.
                             <surefire-plugin-version>${surefire-plugin.version}</surefire-plugin-version>
                             <quarkus-pact-version>${quarkus.pact.version}</quarkus-pact-version>
                             <quarkus-langchain4j-version>${quarkus-langchain4j.version}</quarkus-langchain4j-version>
+                            <code-root>${project.basedir}/../super-heroes</code-root>
                         </attributes>
+                        <!-- WARN catches unterminated blocks, unknown styles, and include errors.
+                             DEBUG would also catch asciidoctor-diagram 'dot' lookup messages which are unavoidable tooling noise. -->
+                        <logHandler>
+                            <failIf>
+                                <severity>WARN</severity>
+                            </failIf>
+                        </logHandler>
                     </configuration>
                 </plugin>
             </plugins>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-docker.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-docker.adoc
@@ -3,28 +3,27 @@
 = Warming up Docker images
 
 To warm up your Docker image repository, navigate to the `quarkus-workshop-super-heroes/super-heroes/infrastructure` directory.
-Here, you will find a
-ifdef::use-mac,use-windows[`docker-compose.yaml`]
-ifdef::use-mac+use-linux[ or ]
-ifdef::use-linux[`docker-compose-linux.yaml`]
-file which defines all the needed Docker images.
+ifdef::use-mac,use-windows[]
+Here, you will find a `docker-compose.yaml` file which defines all the needed Docker images.
+endif::use-mac,use-windows[]
+ifdef::use-linux[]
+Here, you will find a `docker-compose-linux.yaml` file which defines all the needed Docker images.
+endif::use-linux[]
+ifndef::use-mac+use-windows+use-linux[]
+Here, you will find a `docker-compose.yaml` or `docker-compose-linux.yaml` file which defines all the needed Docker images.
+endif::use-mac+use-windows+use-linux[]
 Notice that there is a `db-init` directory with an `initialize-databases.sql` script which sets up our databases, and a `monitoring` directory (all that will be explained later).
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Then execute the following command which will download all the Docker images and start the containers:
 
 [source,shell]
 ----
-ifdef::use-mac,use-windows[]
 docker compose -f docker-compose.yaml up -d
-endif::use-mac,use-windows[]
-ifndef::use-mac,use-windows[]
-docker compose -f docker-compose-linux.yaml up -d
-endif::use-mac,use-windows[]
 ----
---
+====
 
 ifdef::use-linux[]
 [WARNING]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-maven.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-maven.adoc
@@ -2,25 +2,24 @@
 
 == Download the workshop scaffolding
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 First, download the zip file  {github-raw}/dist/quarkus-super-heroes-workshop.zip, and unzip it wherever you want.
 This zip file contains _some_ of the code of the workshop, and you will need to complete it.
---
+====
 
 == Download the Maven dependencies
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Now that you have the initial structure in place, navigate to the root directory and run:
-
 
 [source,shell]
 ----
 ./mvnw clean install
 ----
---
+====
 
 By running this command, it downloads all the required dependencies.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix.adoc
@@ -1,8 +1,7 @@
-[appendix]
-= Installing extra software
+== Appendix: Installing extra software
 
-include::appendix-installing-maven.adoc[leveloffset=+1]
+include::appendix-installing-maven.adoc[leveloffset=+2]
 
-include::appendix-installing-curl.adoc[leveloffset=+1]
+include::appendix-installing-curl.adoc[leveloffset=+2]
 
-include::appendix-preparing-warming-caches.adoc[leveloffset=+1]
+include::appendix-preparing-warming-caches.adoc[leveloffset=+2]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-aca-running-app.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-aca-running-app.adoc
@@ -12,8 +12,8 @@ Before deploying our microservices to Azure Container Apps, we need to create th
 
 === Create a Container Apps environment
 
-[example, role="cta"]
---
+[role="cta"]
+====
 First, let's create the container apps environment.
 A container apps environment acts as a boundary for our containers.
 Containers deployed on the same environment use the same virtual network and the same Log Analytics workspace.
@@ -23,12 +23,12 @@ Create the container apps environment with the following command:
 ----
 include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateACAEnv]
 ----
---
+====
 
 === Create the managed Postgres Databases
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 We need to create three PostgreSQL databases so the Heroes, Villains and Fights microservice can store data.
 Because we also want to access these database from external SQL client, we make them available to the outside world thanks to the `-public all` parameter.
@@ -48,10 +48,10 @@ include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostg
 ----
 include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreatePostgresF]
 ----
---
+====
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Then, we create the database schemas, one for each database:
 
@@ -69,10 +69,10 @@ include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchem
 ----
 include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocCreateSchemaF]
 ----
---
+====
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Now that we have all our databases setup, time to create the tables and add some data to them.
 Each microservice comes with a set of database initialization files as well as some insert statements.
@@ -83,7 +83,7 @@ Create the tables using the following commands (make sure you are under `quarkus
 ----
 include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableH]
 ----
---
+====
 
 [NOTE]
 ====
@@ -101,8 +101,8 @@ include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableV]
 include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocInitTableF]
 ----
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Now, let's add some super heroes and super villains to these databases:
 
@@ -138,7 +138,7 @@ include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataV
 ----
 include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocSelectDataF]
 ----
---
+====
 
 ifdef::use-messaging[]
 === Create the Managed Kafka
@@ -146,8 +146,8 @@ ifdef::use-messaging[]
 The Fight microservice communicates with the Statistics microservice through Kafka.
 We need to create an Azure event hub for that.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 [source,shell,indent=0]
 ----
@@ -171,7 +171,7 @@ include::{projectdir}/infrastructure/azure-setup-aca-env.sh[tags=adocEventHubCon
 If you log into the https://portal.azure.com[Azure Portal] you should see the following created resources.
 
 image::azure-portal-3.png[]
---
+====
 endif::use-messaging[]
 
 == Deploying the Applications
@@ -187,8 +187,8 @@ Therefore, we need to set the right properties using our environment variables.
 Notice that the Heroes microservice has a `--min-replicas` set to 0.
 That means it can scale down to zero if not used (more on that later).
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Create the Heroes container app with the following command:
 
@@ -219,7 +219,7 @@ To access the logs of the Heroes microservice, you can write the following query
 ----
 include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppHeroLogs]
 ----
---
+====
 
 [WARNING]
 ====
@@ -231,8 +231,8 @@ Log analytics can take some time to get initialized.
 
 The Villain microservice also needs to access the managed Postgres database, so we need to set the right variables.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Notice the minimum of replicas is also set to 0:
 
@@ -262,15 +262,15 @@ To access the logs of the Villain microservice, you can write the following quer
 ----
 include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppVillainLogs]
 ----
---
+====
 
 ifdef::use-ai[]
 === Narration Microservice
 
 The Narration microservice does not access any database, just a remote OpenAI/AzureAI service.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 [source,shell,indent=0]
 ----
 include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocCreateAppNarration]
@@ -297,7 +297,7 @@ To access the logs of the Narration microservice, you can write the following qu
 ----
 include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppNarrationLogs]
 ----
---
+====
 endif::use-ai[]
 
 ifdef::use-messaging[]
@@ -305,8 +305,8 @@ ifdef::use-messaging[]
 
 The Statistics microservice listens to a Kafka topics and consumes all the fights.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Create the Statistics container application with the following command:
 
@@ -335,7 +335,7 @@ To access the logs of the Statistics microservice, you can write the following q
 ----
 include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppStatisticsLogs]
 ----
---
+====
 endif::use-messaging[]
 
 === Fights Microservice
@@ -344,8 +344,8 @@ The Fight microservice invokes the Heroes and Villains microservices, sends figh
 We need to configure Kafka (same connection string as the one used by the Statistics microservice) as well as the Postgres database.
 As for the microservice invocations, you need to set the URLs of both Heroes and Villains microservices.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 Create the Fights container application with the following command:
 
@@ -372,7 +372,7 @@ curl "$FIGHTS_URL/api/fights/hello"
 curl "$FIGHTS_URL/api/fights" | jq
 curl "$FIGHTS_URL/api/fights/randomfighters" | jq
 ----
---
+====
 
 To access the logs of the Fight microservice, you can write the following query:
 
@@ -387,8 +387,8 @@ Like for the previous microservices, we will be deploying the UI as Docker image
 But we could have also deployed the Super Hero UI using Azure Static Webapps which is suited for React applications.
 If you are interested in this approach, you can check https://azure.microsoft.com/services/app-service/static/[Azure Static Webapps].
 
-[example, role="cta"]
---
+[role="cta"]
+====
 
 For now, let's continue with Azure Container Apps and deploy the UI as a Docker image with the following command:
 
@@ -406,7 +406,7 @@ include::{projectdir}/infrastructure/azure-deploy-aca.sh[tags=adocAppUIURL]
 ----
 open "$UI_URL"
 ----
---
+====
 
 To access the UI logs, you can write the following query:
 
@@ -427,4 +427,3 @@ curl "$FIGHTS_URL/api/fights/randomfighters" | jq
 open "$STATISTICS_URL"
 open "$UI_URL"
 ----
-

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-local-running-app.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-azure-container-apps/azure-local-running-app.adoc
@@ -10,8 +10,8 @@ Later we will deploy them on Azure Container Apps.
 
 In the previous chapter we have built our Docker containers and run locally thanks to Docker Compose.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 Check that you have all the Docker images installed locally before going further by executing the following command:
 
 [source,shell]
@@ -35,7 +35,7 @@ ifdef::use-ai[]
 <org>/rest-narration          1.0.0-SNAPSHOT       fcfe334594f3   390MB
 endif::use-ai[]
 ----
---
+====
 
 Now we will tag the images, push them to Azure Container Registry and execute them locally, again, with Docker Compose.
 
@@ -44,8 +44,8 @@ Now we will tag the images, push them to Azure Container Registry and execute th
 Make sure you've set all the environment variables defined in the previous chapter and that you've also created the resource group and the Azure Container Registry.
 ====
 
-[example, role="cta"]
---
+[role="cta"]
+====
 Before you can push an image to your registry, you must tag it with the fully qualified name of your registry login server (the `REGISTRY_URL` variable).
 Tag the image using the `docker tag` commands (make sure to change the value of `quarkus/` by the value of your local organisation):
 
@@ -60,10 +60,10 @@ include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocTaggi
 endif::use-ai[]
 
 ----
---
+====
 
-[example, role="cta"]
---
+[role="cta"]
+====
 Make sure all the images have properly been tagged by executing the following command:
 
 [source,shell]
@@ -87,10 +87,10 @@ ifdef::use-ai[]
 registrysuperheroes<uniquename>.azurecr.io/narration-app         1.0    50c657de360d  432MB
 endif::use-ai[]
 ----
---
+====
 
-[example, role="cta"]
---
+[role="cta"]
+====
 To be able to push these Docker images to Azure Registry, we first need to log in to the registry:
 
 [source,shell,indent=0]
@@ -130,7 +130,7 @@ include::{projectdir}/infrastructure/azure-build-push-registry.sh[tags=adocShowi
 You can visualize the content of the registry on the https://portal.azure.com[Azure Portal].
 
 image::azure-portal-4.png[]
---
+====
 
 == Running Remote Images Locally
 
@@ -138,20 +138,20 @@ Now that we have our docker images pushed to Azure Container Registry, we can ru
 We will use the `docker-compose-app-remote.yaml` file under `super-heroes/infrastructure` to run the remote images locally.
 But before we need to change a few things.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 You should edit the `docker-compose-app-remote.yaml` file under `super-heroes/infrastructure` and change the name `registrysuperheroesagoncal` with the value of the `$REGISTRY` variable.
---
+====
 
-[example, role="cta"]
---
+[role="cta"]
+====
 Now that we have all our Docker containers pushed to Azure Container Registry, let's execute them with:
 
 [source,shell]
 ----
 docker compose -f docker-compose-app-remote.yaml up
 ----
---
+====
 s
 Once all the containers are started, you can:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-native/native.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-native/native.adoc
@@ -34,8 +34,8 @@ Let's create native executables for all our microservices.
 Well, maybe not all of them.
 Let's see.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 From the root `super-heroes` directory, run the following commands (to speed up the compilation you can also skip the tests by adding `-Dmaven.test.skip=true`):
 
 [source,shell]
@@ -48,6 +48,7 @@ ifdef::use-messaging[]
 ./mvnw --file event-statistics/pom.xml package -Pnative
 endif::use-messaging[]
 ----
+====
 
 [WARNING]
 ====
@@ -131,8 +132,8 @@ Notice that there is no `.jar` file extension.
 It's just a binary file that you can execute directly like any other binary.
 Let's execute the entire application in native mode.
 
-[example, role="cta"]
---
+[role="cta"]
+====
 Native mode is using the `prod` profile, meaning that the infrastructure needs to be up and running (`docker compose -f docker-compose.yaml up -d`).
 Then, from the root `super-heroes` directory, run the following commands (to speed up the compilation you can also skip the tests by adding `-Dmaven.test.skip=true`):
 
@@ -151,7 +152,7 @@ endif::use-ai[]
 ----
 
 You can then go to http://localhost:8080 and start new fights.
---
+====
 
 // == Testing the Native Executables
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-quarkus-extension/quarkus-extension.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-quarkus-extension/quarkus-extension.adoc
@@ -49,9 +49,8 @@ As stated above, an extension is divided into two parts, called `deployment` (au
 include::{plantDir}/8-extension-architecture.puml[]
 ----
 
-[example, role="cta"]
---
-
+[role="cta"]
+====
 From the directory `super-heroes` execute the following commands:
 
 [source,shell,subs="attributes+"]
@@ -63,7 +62,7 @@ From the directory `super-heroes` execute the following commands:
     -DgroupId=io.quarkus.workshop.super-heroes \
     -DpackageName=io.quarkus.workshop.superheroes.version
 ----
---
+====
 
 This command creates the structure for the version extension:
 
@@ -136,16 +135,15 @@ The _runtime_ part of an extension contains only the classes and resources requi
 For the version extension, it would be a single class that prints the version.
 
 First, let's create the configuration class that will allow users to dynamically configure whether the version should be printed:
-[example, role="cta"]
---
-
+[role="cta"]
+====
 Under the `runtime` module, create the `src/main/java` directory, and, in this directory, create a new interface named `io.quarkus.workshop.superheroes.version.runtime.VersionConfig` with the following content:
 
 [source,java]
 ----
 include::{code-root}/extension-version/runtime/src/main/java/io/quarkus/workshop/superheroes/version/runtime/VersionConfig.java[]
 ----
---
+====
 The `@ConfigMapping` annotation declares `VersionConfig` as a configuration interface which configuration properties are prefixed with `quarkus.version` prefix. It is also used in CDI aware environments to scan and register Config Mappings.
 
 The `@ConfigRoot` annotation declares that the configuration is available during runtime.
@@ -154,16 +152,15 @@ The `@WithDefault("true")` is used to declare the default value returned when `e
 
 By default, the name of the property is derived from what's declared in the `prefix` attribute inside `@ConfigMapping` plus the name of the method. In our case, the user-configured property will be `quarkus.version.enabled`.
 
-[example, role="cta"]
---
-
+[role="cta"]
+====
 Still in the `runtime` module, create the `io.quarkus.workshop.superheroes.version.runtime.VersionRecorder` class with the following content:
 
 [source,java]
 ----
 include::{code-root}/extension-version/runtime/src/main/java/io/quarkus/workshop/superheroes/version/runtime/VersionRecorder.java[]
 ----
---
+====
 
 Simple right?
 But how does it work?
@@ -177,16 +174,15 @@ We will see how this recorder is used from the _deployment_ module.
 This module contains _build steps_, i.e., methods called during the augmentation phase and computing just enough bytecode to serve the services the application requires.
 The version extension consists of a single build step that extracts the version and uses the `VersionRecorder`.
 
-[example, role="cta"]
---
-
+[role="cta"]
+====
 Next, open the `ExtensionVersionProcessor` class, and update the content to be:
 
 [source, java]
 ----
 include::{code-root}/extension-version/deployment/src/main/java/io/quarkus/workshop/superheroes/version/deployment/ExtensionVersionProcessor.java[]
 ----
---
+====
 This class is the core of the extension.
 It contains a set of methods annotated with `@BuildStep`.
 
@@ -216,22 +212,20 @@ Any invocations made on these proxies will be recorded, and bytecode will be wri
 
 == Packaging the extension
 
-[example, role="cta"]
---
-
+[role="cta"]
+====
 From the root directory of the extension, run:
 
 [source,shell]
 ----
 ./mvnw clean install
 ----
---
+====
 
 == Using the extension
 
-[example, role="cta"]
---
-
+[role="cta"]
+====
 Go back to the _villain_ microservice, and add the following dependency to the `pom.xml` file:
 
 [source,xml,indent=0]
@@ -245,7 +239,7 @@ If not yet started, start the microservice with:
 ----
 ./mvnw quarkus:dev
 ----
---
+====
 
 And the version will be displayed:
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -187,4 +187,4 @@ include::core-conclusion/conclusion-references.adoc[leveloffset=+2]
 <<<
 
 // Appendix
-include::core-appendix/appendix.adoc[leveloffset=+1]
+include::core-appendix/appendix.adoc[]


### PR DESCRIPTION
I'm keen to avoid a repeat of the problem fixed by #623. Tests help, but I'd like to fail even faster, by using linting. I explored asciidoc linting, but then realised all I needed to do was just change how strict the actual asciidoc compilation was. I was tempted to use `DEBUG` since some useful errors about syntax were hidden at `DEBUG` level, but on clean builds there was some debug logging from `dot` that I couldn't fix. So I've gone with `WARN`. 

To get `WARN` clean, I had to fix a few further issues (this is where we're happy to have tests). 

This is the problems we currently have:

```
[INFO] asciidoctor: DEBUG: optional-quarkus-extension/quarkus-extension.adoc: line 346: unknown style for paragraph: appendix
[INFO] asciidoctor: WARN: core-appendix/appendix-preparing-warming-docker.adoc: line 27: unterminated open block
[INFO] Converted /Users/holly/Code/quarkus/quarkus-workshops/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
[ERROR] asciidoctor: DEBUG: optional-quarkus-extension/quarkus-extension.adoc: line 346: unknown style for paragraph: appendix
[ERROR] asciidoctor: WARN: core-appendix/appendix-preparing-warming-docker.adoc: line 27: unterminated open block
```

So my changes are: 

- Add logHandler failIf to fail the build on any asciidoc WARN or above. Fix all warnings that this surfaces:
- Convert CTA blocks from open blocks (--) to example blocks (====) in files that were producing unterminated open block warnings
- Remove [appendix] style which triggered "unknown style" warnings
- Add missing closing delimiter for unterminated CTA block in native.adoc
- Add code-root as Maven attribute so includes resolve inside ==== blocks