### PR TITLE
Bump asciidoctorj to 3.0.1 and asciidoctor-maven-plugin to 3.2.0

### DIFF
--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -34,7 +34,7 @@ The default build will take around 50m.
     <properties>
         <version.asciidoctor.maven.plugin>2.2.4</version.asciidoctor.maven.plugin>
         <version.jruby>9.4.5.0</version.jruby>
-        <version.asciidoctorj>2.5.10</version.asciidoctorj>
+        <version.asciidoctorj>3.0.1</version.asciidoctorj>
         <version.asciidoctorj.pdf>2.3.9</version.asciidoctorj.pdf>
         <version.asciidoctorj.diagram>2.2.13</version.asciidoctorj.diagram>
         <!-- If building docs locally and urls matter, set environment variables for these values -->

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -32,7 +32,7 @@ The default build will take around 50m.
     <name>Quarkus Workshop :: Docs</name>
 
     <properties>
-        <version.asciidoctor.maven.plugin>2.2.4</version.asciidoctor.maven.plugin>
+        <version.asciidoctor.maven.plugin>3.2.0</version.asciidoctor.maven.plugin>
         <version.jruby>9.4.5.0</version.jruby>
         <version.asciidoctorj>3.0.1</version.asciidoctorj>
         <version.asciidoctorj.pdf>2.3.9</version.asciidoctorj.pdf>
@@ -203,11 +203,12 @@ The default build will take around 50m.
                             <resources>
                                 <resource>
                                     <directory>${project.basedir}/src/docs/asciidoc</directory>
-                                    <filtering>false</filtering>
-                                    <include>assets/**</include>
-                                    <include>images/**</include>
-                                    <!-- And add in the html configurator to the top-level -->
-                                    <include>*html</include>
+                                    <includes>
+                                        <include>assets/**</include>
+                                        <include>images/**</include>
+                                        <!-- And add in the html configurator to the top-level -->
+                                        <include>*html</include>
+                                    </includes>
                                 </resource>
                             </resources>
                             <attributes>
@@ -291,7 +292,9 @@ The default build will take around 50m.
                                         <resources>
                                             <resource>
                                                 <directory>src/</directory>
-                                                <exclude>**</exclude>
+                                                <excludes>
+                                                    <exclude>**</exclude>
+                                                </excludes>
                                             </resource>
                                         </resources>
                                     </configuration>


### PR DESCRIPTION

- Bumps `org.asciidoctor:asciidoctorj` from 2.5.10 to 3.0.1 (from Dependabot PR #640)
- Bumps `asciidoctor-maven-plugin` from 2.2.4 to 3.2.0 for compatibility with the new asciidoctorj API
- Fixes resource configuration for plugin 3.x: wraps `<include>`/`<exclude>` in `<includes>`/`<excludes>` and removes unsupported `<filtering>` element

Supersedes #640, which failed CI because the plugin wasn't bumped alongside asciidoctorj.
