### PR TITLE
Remove redundant OS directories from site assembly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,11 @@ jobs:
           cp -r target/generated-asciidoc/mac/variants/* target/generated-asciidoc/variants
           cp -r target/generated-asciidoc/windows/variants/* target/generated-asciidoc/variants
 
+          # Remove the OS-specific directories now that their variants are merged
+          rm -rf target/generated-asciidoc/linux
+          rm -rf target/generated-asciidoc/mac
+          rm -rf target/generated-asciidoc/windows
+
           # Move things around to preserve the super-heroes structure
           mkdir -p target/site/super-heroes
           cp -R target/generated-asciidoc/* target/site/super-heroes

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,6 @@ jobs:
           rm -f pr-id.txt
       - name: Trim site for preview
         run: |
-          rm -rf super-heroes/linux super-heroes/mac super-heroes/windows
           cd super-heroes/variants
           rm -rf os-linux-* os-windows-*
           du -sh ..


### PR DESCRIPTION
The work to parallelise the site build ended up creatinga *lot*  extra files during the assembly. This fix should remove the size of what we upload to github pages, reduce the size of what we upload to surge, and might even speed up the variants-testing in the unit tests, depending whether the search drills down multiple folder levels. 

- After merging OS-specific variants into the root `variants/` folder, the `linux/`, `mac/`, and `windows/` directories were being copied into the final site unchanged
- These directories each contained a `spine.html` built with default options (not OS-specific), an incomplete `variants/` folder (only that OS's variants), and a copy of the configurator `index.html`
- If someone landed on e.g. `super-heroes/mac/index.html` and selected Windows, the generated URL would point to a variant that doesn't exist
- This PR removes those directories after the variant merge, and cleans up the now-unnecessary `rm` in `preview.yml`
