### PR TITLE
Bump docs + CI java to 25, bump JRuby to 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
     strategy:
       matrix:
         os: [ "all","linux","mac","windows" ]
+    env:
+      MAVEN_OPTS: "-Xmx4g"
     steps:
       - uses: actions/checkout@v6
       - name: Install JDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,15 @@ permissions:
   id-token: write
 
 jobs:
-  build_java17:
+  build_java:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install JDK 17
+      - name: Install JDK
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
           cache: maven
       - name: Microservices build with Maven
         run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml
@@ -33,11 +33,11 @@ jobs:
         os: [ "all","linux","mac","windows" ]
     steps:
       - uses: actions/checkout@v6
-      - name: Install JDK 17
+      - name: Install JDK
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
           cache: maven
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -65,7 +65,7 @@ jobs:
           if-no-files-found: error
           retention-days: 3
   publication:
-    needs: [ docs, build_java17 ]
+    needs: [ docs, build_java ]
     runs-on: ubuntu-latest
     steps:
       - name: Download default site
@@ -122,11 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install JDK 17
+      - name: Install JDK
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
           cache: maven
       - name: Cache Playwright browsers
         uses: actions/cache@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         os: [ "all","linux","mac","windows" ]
     env:
-      MAVEN_OPTS: "-Xmx4g"
+      MAVEN_OPTS: "-Xmx8g"
     steps:
       - uses: actions/checkout@v6
       - name: Install JDK

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -12,31 +12,31 @@ permissions:
   contents: write
 
 jobs:
-  build_java17:
+  build_java:
     runs-on: ubuntu-latest
     concurrency: zip-generation
     steps:
       - uses: actions/checkout@v6
-      - name: Install JDK 17
+      - name: Install JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
       - name: Microservices build with Maven
         run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml
       - name: Native build with Maven
         run: mvn -B install --file quarkus-workshop-super-heroes/pom.xml -Pnative -Dquarkus.native.container-build=true -DskipITs -pl '!:rest-narration,!:extension-version'
   publication:
-    needs: [ build_java17 ]
+    needs: [ build_java ]
     runs-on: ubuntu-latest
     concurrency: zip-generation
     steps:
       - uses: actions/checkout@v6
-      - name: Install JDK 17
+      - name: Install JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
       - name: Generate zips
         run: |
           cd quarkus-workshop-super-heroes/

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -33,14 +33,16 @@ The default build will take around 50m.
 
     <properties>
         <version.asciidoctor.maven.plugin>3.2.0</version.asciidoctor.maven.plugin>
-        <version.jruby>9.4.5.0</version.jruby>
+        <version.jruby>10.1.0.0</version.jruby>
         <version.asciidoctorj>3.0.1</version.asciidoctorj>
         <version.asciidoctorj.pdf>2.3.9</version.asciidoctorj.pdf>
         <version.asciidoctorj.diagram>2.2.13</version.asciidoctorj.diagram>
         <version.playwright>1.59.0</version.playwright>
         <version.junit>5.11.4</version.junit>
         <!-- If building docs locally and urls matter, set environment variables for these values -->
-        <github.raw>https://raw.githubusercontent.com/${env.GITHUB_REPOSITORY}/${env.GITHUB_REF}/quarkus-workshop-super-heroes</github.raw>
+        <github.raw>
+            https://raw.githubusercontent.com/${env.GITHUB_REPOSITORY}/${env.GITHUB_REF}/quarkus-workshop-super-heroes
+        </github.raw>
         <github.repo>${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}</github.repo>
         <github.url>${github.repo}/tree/${env.GITHUB_REF}/quarkus-workshop-super-heroes</github.url>
         <base.url>${env.BASE_URL}</base.url>
@@ -54,8 +56,8 @@ The default build will take around 50m.
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <exec-plugin.version>3.6.3</exec-plugin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -272,7 +274,8 @@ The default build will take around 50m.
                             </resources>
                             <attributes>
                                 <options-file>default-options.adoc</options-file>
-                                <imagesdir>images</imagesdir> <!-- I don't know why this has to be specified as one level above the plantuml dir, when they're siblings, but it does -->
+                                <imagesdir>images
+                                </imagesdir> <!-- I don't know why this has to be specified as one level above the plantuml dir, when they're siblings, but it does -->
                                 <assetsdir>assets</assetsdir>
                             </attributes>
                         </configuration>
@@ -294,7 +297,8 @@ The default build will take around 50m.
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>${basedir}/src/resource-generation/generate-attribute-combinations.sh</executable>
+                            <executable>${basedir}/src/resource-generation/generate-attribute-combinations.sh
+                            </executable>
                             <arguments>
                                 <argument>${options.files.directory}</argument>
                             </arguments>
@@ -343,7 +347,8 @@ The default build will take around 50m.
                                         </outputDirectory>
                                         <attributes>
                                             <options-file>${options.files.directory}/@item@/options.adoc</options-file>
-                                            <diagram-cachedir>${project.build.directory}/generated-asciidoc/variants/</diagram-cachedir>
+                                            <diagram-cachedir>${project.build.directory}/generated-asciidoc/variants/
+                                            </diagram-cachedir>
                                             <imagesdir>../../images</imagesdir>
                                             <assetsdir>../../assets</assetsdir>
                                         </attributes>
@@ -375,7 +380,9 @@ The default build will take around 50m.
             </activation>
             <properties>
                 <base.url>http://quarkus.io/</base.url>
-                <github.raw>https://raw.githubusercontent.com/quarkusio/quarkus-workshops/main/quarkus-workshop-super-heroes</github.raw>
+                <github.raw>
+                    https://raw.githubusercontent.com/quarkusio/quarkus-workshops/main/quarkus-workshop-super-heroes
+                </github.raw>
                 <github.repo>http://github.com/quarkusio/quarkus-workshops</github.repo>
             </properties>
         </profile>
@@ -400,7 +407,8 @@ The default build will take around 50m.
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${basedir}/src/resource-generation/generate-attribute-combinations.sh</executable>
+                                    <executable>${basedir}/src/resource-generation/generate-attribute-combinations.sh
+                                    </executable>
                                     <arguments>
                                         <argument>${options.files.directory}</argument>
                                         <argument>${os}</argument>


### PR DESCRIPTION
Supersedes https://github.com/quarkusio/quarkus-workshops/pull/628. 

JRuby 10 needs Java 21 or higher. It's got various performance optimisations, including Leyden-readiness, so it's probably worth updating. I've bumped the Java level used for building the docs to 25, and also bumped the JDK used in general CI to 25, but kept the compiler.source in the other projects at 17 (for now). 