### PR TITLE
Fix preview teardown PR comment and pin surge version

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Teardown surge preview
         id: deploy
-        run: npx surge teardown https://quarkus-workshops-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
+        run: npx surge@0.23.1 teardown https://quarkus-workshops-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }} || echo "NOT_TORNDOWN=true" >> "$GITHUB_ENV"
       - name: Update PR status comment
         uses: quarkusio/action-helpers@main
         if: env.NOT_TORNDOWN != 'true'
@@ -20,5 +20,5 @@ jobs:
           body: |
             🙈 The PR is closed and the preview is expired.
           body-marker: '<!-- Sticky Pull Request Comment -->'
-          pr-number: ${{ steps.pr.outputs.id }}
+          pr-number: ${{ github.event.number }}
 

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -37,6 +37,7 @@ The default build will take around 50m.
         <version.asciidoctorj>2.5.10</version.asciidoctorj>
         <version.asciidoctorj.pdf>2.3.9</version.asciidoctorj.pdf>
         <version.asciidoctorj.diagram>3.2.1</version.asciidoctorj.diagram>
+        <version.asciidoctorj.diagram.plantuml>1.2025.3</version.asciidoctorj.diagram.plantuml>
         <version.playwright>1.59.0</version.playwright>
         <version.junit>5.11.4</version.junit>
         <!-- If building docs locally and urls matter, set environment variables for these values -->
@@ -152,6 +153,11 @@ The default build will take around 50m.
                             <groupId>org.asciidoctor</groupId>
                             <artifactId>asciidoctorj-diagram</artifactId>
                             <version>${version.asciidoctorj.diagram}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj-diagram-plantuml</artifactId>
+                            <version>${version.asciidoctorj.diagram.plantuml}</version>
                         </dependency>
                     </dependencies>
                     <configuration>

--- a/quarkus-workshop-super-heroes/docs/pom.xml
+++ b/quarkus-workshop-super-heroes/docs/pom.xml
@@ -36,7 +36,7 @@ The default build will take around 50m.
         <version.jruby>9.4.5.0</version.jruby>
         <version.asciidoctorj>2.5.10</version.asciidoctorj>
         <version.asciidoctorj.pdf>2.3.9</version.asciidoctorj.pdf>
-        <version.asciidoctorj.diagram>2.2.13</version.asciidoctorj.diagram>
+        <version.asciidoctorj.diagram>3.2.1</version.asciidoctorj.diagram>
         <version.playwright>1.59.0</version.playwright>
         <version.junit>5.11.4</version.junit>
         <!-- If building docs locally and urls matter, set environment variables for these values -->


### PR DESCRIPTION
Most preview teardowns are failing, except in cases where a preview was never actually created.

- Fix `pr-number` in the teardown workflow: it referenced `steps.pr.outputs.id` which doesn't exist in this workflow — use `github.event.number` instead (directly available from the `pull_request_target` trigger)
- Pin surge to `0.23.1` to match the version used in `preview.yml`, avoiding potential compatibility issues from unpinned `npx surge`


The teardown comment step was always failing when it ran, because the `pr` step only exists in `preview.yml` (where it reads from an artifact). The bug was masked in many cases because when surge teardown itself fails (e.g., preview was never deployed), the `NOT_TORNDOWN` env var skips the comment step entirely.
