### PR TITLE
Use new API for handwritten style in PlantUML diagrams

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-microservices/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-microservices/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-reactive/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-reactive/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest-client/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest-client/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-ai/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-ai/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-quarkus-extension/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-quarkus-extension/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-fights-sequence.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-fights-sequence.puml
@@ -1,7 +1,7 @@
 @startuml
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 
 skinparam participant {
     backgroundColor<<frontend>> #D2B4DE

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/style.puml
@@ -1,6 +1,6 @@
+!option handwritten true
 skinparam dpi 300
 skinparam useBetaStyle true
-skinparam handwritten true
 allow_mixing
 
 skinparam node {


### PR DESCRIPTION
I spotted too late that upgrading the version of plantuml brought an API change, so we now get this warning: 

<img width="640" height="116" alt="image" src="https://github.com/user-attachments/assets/8a9fa79e-c2d5-4139-b1f6-272b239e143d" />
