### PR TITLE
Add permissions to teardown workflow

### DIFF
--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [ closed ]
 
+permissions:
+  pull-requests: write
+
 jobs:
   preview-teardown:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The previous fix for the teardown workflow got things further, but not actually to green. The problem is a most likely a missing permission, so adding that. 