### PR TITLE
Add dependabot cooldown and preview warning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,23 @@ updates:
     open-pull-requests-limit: 40
     schedule:
       interval: daily
+    cooldown:
+      default-days: 4
     labels:
       - "version-upgrade"
     pull-request-branch-name:
       separator: "_"
+  - package-ecosystem: "npm"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     labels:
       - infra
     pull-request-branch-name:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,7 +42,7 @@ jobs:
           action: maintain-one-comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh
+            🚀 PR Preview ${{ github.sha }} has been successfully built and deployed to https://quarkus-workshops-pr-${{ steps.pr.outputs.id }}-preview.surge.sh. Note that in order to limit the site size, not all variants are deployed.
           body-marker: '<!-- Sticky Pull Request Comment -->'
           pr-number: ${{ steps.pr.outputs.id }}
       - name: Update PR status comment on failure


### PR DESCRIPTION
To help shield against supply chain attacks, I've added a cooldown to dependabot updates. Vulnerability updates get PRs immediately, independent of the cooldown. 

I also noticed we weren't using dependabot for all the UI, so I've added it there. I expect an explosion of PRs. :/ (We do have tests, but I'm not sure we have e2e tests for the UI.)

I also added an extra bit to the preview comment explaining that not all content gets deployed (should have done that when I did the original fix). 

