### PR TITLE
Drop semantic kernel from diagrams and use guard for azure AI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,3 @@ node/
 .classpath
 .settings
 .factorypath
-
-
-# Semantic Kernel
-conf.properties

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture-ai.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture-ai.puml
@@ -21,11 +21,15 @@ node "Villain" as villain {
 
 node "Narration" as narration {
     agent "Quarkus" <<application>> as narrationQuarkus
-    hexagon "Semantic Kernel" as sk
+    hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
 }
 
+!ifdef use_azure
 cloud "Open AI \n Azure OpenAI" as openai
+!else
+cloud "LLM Provider \n (OpenAI, Ollama, etc.)" as openai
+!endif
 
 node "Fight" as fight {
     agent "Quarkus" <<application>> as fightQuarkus

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5a-ai-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5a-ai-physical-architecture.puml
@@ -21,11 +21,15 @@ node "Villain" as villain {
 
 node "Narration" as narration {
     agent "Quarkus" <<application>> as narrationQuarkus
-    hexagon "Semantic Kernel" as sk
+    hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
 }
 
+!ifdef use_azure
 cloud "Open AI \n Azure OpenAI" as openai
+!else
+cloud "LLM Provider \n (OpenAI, Ollama, Gemini, etc.)" as openai
+!endif
 
 node "Fight" as fight {
     agent "Quarkus" <<application>> as fightQuarkus

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5b-ai-narration-microservice.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5b-ai-narration-microservice.puml
@@ -5,11 +5,15 @@ left to right direction
 
 node "Narration" as hero {
     agent "Quarkus" <<application>> as narrationQuarkus
-    hexagon "Semantic Kernel" as sk
+    hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
 }
 
+!ifdef use_azure
 cloud "Open AI \n Azure OpenAI" as openai
+!else
+cloud "LLM Provider \n (OpenAI, Ollama, Gemini, etc.)" as openai
+!endif
 
 REST ()-- narrationQuarkus
 sk --> openai : HTTP


### PR DESCRIPTION
I noticed we still reference Semantic Kernel in the diagrams, so I've fixed that. 

I also spotted that we hardcode Azure as the LLM provider, so I've put a guard on that.

In the non-azure case, it will be this, except I dropped 'Gemini' on the first diagram for concision:

<img width="1906" height="1006" alt="image" src="https://github.com/user-attachments/assets/afdb8f6e-6a0e-417a-b6e5-5e63e8362ad1" />
