### PR TITLE
Restyle PlantUML diagrams to match Quarkus brand

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture-ai.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture-ai.puml
@@ -4,23 +4,23 @@
 left to right direction
 
 node "Super Hero UI" as ui {
-    agent "Quarkus" <<frontend>> as uiQuarkus
+    agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
 node "Narration" as narration {
-    agent "Quarkus" <<application>> as narrationQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as narrationQuarkus
     hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
 }
@@ -32,7 +32,7 @@ cloud "LLM Provider \n (OpenAI, Ollama, etc.)" as openai
 !endif
 
 node "Fight" as fight {
-    agent "Quarkus" <<application>> as fightQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
 }
@@ -40,7 +40,7 @@ node "Fight" as fight {
 package "stats" {
     node "Statistics" as stat {
         agent "HTML+JQuery" <<frontend>> as statUI
-        agent "Quarkus (imperative)" <<application>> as statQuarkus
+        agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as statQuarkus
         statUI .up> statQuarkus
     }
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture.puml
@@ -4,23 +4,23 @@
 left to right direction
 
 node "Super Hero UI" as ui {
-    agent "Quarkus" <<frontend>> as uiQuarkus
+    agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
 node "Fight" as fight {
-    agent "Quarkus" <<application>> as fightQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
 }
@@ -28,7 +28,7 @@ node "Fight" as fight {
 package "stats" {
     node "Statistics" as stat {
         agent "HTML+JQuery" <<frontend>> as statUI
-        agent "Quarkus (imperative)" <<application>> as statQuarkus
+        agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as statQuarkus
         statUI .up> statQuarkus
     }
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/1-rest-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/1-rest-physical-architecture.puml
@@ -4,11 +4,12 @@
 left to right direction
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-REST ()-- villainQuarkus
+() "REST" as rest #4695EB
+rest -- villainQuarkus
 
 @enduml

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/3-reactive-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/3-reactive-physical-architecture.puml
@@ -4,11 +4,12 @@
 left to right direction
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-REST ()-- heroQuarkus
+() "REST" as rest #4695EB
+rest -- heroQuarkus
 
 @enduml

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-fights-sequence.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-fights-sequence.puml
@@ -1,9 +1,30 @@
 @startuml
 skinparam dpi 300
+skinparam defaultFontName "Open Sans"
+skinparam defaultFontColor #091313
 
 skinparam participant {
-    backgroundColor<<frontend>> #D2B4DE
-    backgroundColor<<application>> #FAE5D3
+    backgroundColor<<frontend>> #4695EB
+    fontColor<<frontend>> #FFFFFF
+    borderColor<<frontend>> #1A3A5C
+    backgroundColor<<application>> #F0EDE8
+    fontColor<<application>> #091313
+    borderColor<<application>> #9E9A95
+}
+
+skinparam arrow {
+    fontName "Open Sans"
+    color #FF004A
+    fontColor #555555
+    thickness 2
+    fontSize 13
+}
+
+skinparam sequence {
+    lifeLineBorderColor #1A3A5C
+    lifeLineBackgroundColor #EBF3FD
+    activationBackgroundColor #D6E6FA
+    activationBorderColor #1A3A5C
 }
 
 participant UI as UI <<frontend>>

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-physical-architecture.puml
@@ -4,23 +4,23 @@
 left to right direction
 
 node "Super Hero UI" as ui {
-    agent "Quarkus" <<frontend>> as uiQuarkus
+    agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
 node "Fight" as fight {
-    agent "Quarkus" <<application>> as fightQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
 }

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5-rest-client-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5-rest-client-physical-architecture.puml
@@ -4,23 +4,23 @@
 left to right direction
 
 node "Super Hero UI" as ui {
-    agent "Quarkus" <<frontend>> as uiQuarkus
+    agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
 node "Fight" as fight {
-    agent "Quarkus" <<application>> as fightQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
 }

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5a-ai-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5a-ai-physical-architecture.puml
@@ -4,23 +4,23 @@
 left to right direction
 
 node "Super Hero UI" as ui {
-    agent "Quarkus" <<frontend>> as uiQuarkus
+    agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
 node "Narration" as narration {
-    agent "Quarkus" <<application>> as narrationQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as narrationQuarkus
     hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
 }
@@ -32,7 +32,7 @@ cloud "LLM Provider \n (OpenAI, Ollama, Gemini, etc.)" as openai
 !endif
 
 node "Fight" as fight {
-    agent "Quarkus" <<application>> as fightQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
 }

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5b-ai-narration-microservice.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5b-ai-narration-microservice.puml
@@ -4,7 +4,7 @@
 left to right direction
 
 node "Narration" as hero {
-    agent "Quarkus" <<application>> as narrationQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as narrationQuarkus
     hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
 }
@@ -15,7 +15,8 @@ cloud "Open AI \n Azure OpenAI" as openai
 cloud "LLM Provider \n (OpenAI, Ollama, Gemini, etc.)" as openai
 !endif
 
-REST ()-- narrationQuarkus
+() "REST" as rest #4695EB
+rest -- narrationQuarkus
 sk --> openai : HTTP
 
 @enduml

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/6-messaging-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/6-messaging-physical-architecture.puml
@@ -4,23 +4,23 @@
 left to right direction
 
 node "Super Hero UI" as ui {
-    agent "Quarkus" <<frontend>> as uiQuarkus
+    agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
 node "Fight" as fight {
-    agent "Quarkus" <<application>> as fightQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
 }
@@ -28,7 +28,7 @@ node "Fight" as fight {
 package "stats" {
     node "Statistics" as stat {
         agent "HTML+JQuery" <<frontend>> as statUI
-        agent "Quarkus (imperative)" <<application>> as statQuarkus
+        agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as statQuarkus
         statUI .up> statQuarkus
     }
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/7-observability-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/7-observability-physical-architecture.puml
@@ -4,23 +4,23 @@
 left to right direction
 
 node "Super Hero UI" as ui {
-    agent "Quarkus" <<frontend>> as uiQuarkus
+    agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
 node "Hero" as hero {
-    agent "Quarkus (reactive)" <<application>> as heroQuarkus
+    agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
 node "Villain" as villain {
-    agent "Quarkus (imperative)" <<application>> as villainQuarkus
+    agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
 node "Fight" as fight {
-    agent "Quarkus" <<application>> as fightQuarkus
+    agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
 }
@@ -28,7 +28,7 @@ node "Fight" as fight {
 package "stats" {
     node "Statistics" as stat {
         agent "HTML+JQuery" <<frontend>> as statUI
-        agent "Quarkus (imperative)" <<application>> as statQuarkus
+        agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as statQuarkus
         statUI .up> statQuarkus
     }
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/8-extension-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/8-extension-architecture.puml
@@ -4,17 +4,17 @@
 left to right direction
 
 package "version-deployment" as deployment {
-    class VersionConfig {
+    class VersionConfig <<(C,#D6E6FA)>> {
         boolean enabled
     }
 
-    class VersionExtensionProcessor {
+    class VersionExtensionProcessor <<(C,#D6E6FA)>> {
         @BuildStep @Record recordVersion()
     }
 }
 
 package "version" as runtime {
-    class VersionRecorder {
+    class VersionRecorder <<(C,#D6E6FA)>> {
         print(String version)
     }
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/style.puml
@@ -1,34 +1,120 @@
+!define QUARKUS_BLUE #4695EB
+!define QUARKUS_RED #FF004A
+!define QUARKUS_NEAR_BLACK #091313
+!define DARK_BLUE_GRAY #1A3A5C
+!define LIGHT_BLUE #D6E6FA
+!define PALE_BLUE #EBF3FD
+!define MEDIUM_BLUE #7AB3F0
+!define WARM_GRAY #F0EDE8
+!define WARM_GRAY_BORDER #9E9A95
+!define LIGHT_PURPLE #E0D4F5
+!define DARK_PURPLE #6B5B95
+!define LIGHT_GRAY #E8ECF0
+!define LABEL_GRAY #555555
+!define QUARKUS_ICON <$quarkus*0.078>
+
+sprite $quarkus [256x312/16z] {
+xCz10O0040IXQs3_jZutWmuqu7u7000000000000uFcmxdso-QdkfxgVwdwg-uds9zgVwdwY_Ods9zgVQ7-Y_V5FzYVQdsX__9FzyLy_oN_z9F_rayxV_sNd
+Jj8ZnC4O37C3tV-slSgZXJEeMtzXFZTa3fQAj-O29zb8sfApZjJ_2zYX-fXsAZ-ndSsFT4Vp0zxhFvd_b-_r1tpsGlBp_Q__zR_-ro_D6dX-QKxFz4ipUgvV
+0toqNshrR7zVmlUhw-3xfQw1xvUwFDylTMc-NrsOxvUwADylTK6-N-fYVB-w5DylTHc-N-eIVB-I0D-VLqld-NEIT9o_dN_q-j_h__dtV_xcD7_YMRu_o1ze
+bX-Fz__CFVhvRqGz__MFAuCrX_gzBbXvd3--P-3xczcsP_glWEzXU7-k3uRI_RdUmm_ov_ermVTVCNy9SVsLta6ilzGxZFONUkUn_glZkmBfx_NU19v_Hk-D
+0FerjY3z6bnuVeqkmDl_BF-z_VFyrnWVv_zApkabaj_PAJt7xzAfvx_UrEVxNTfV1PntwxFzBbq4fTwj3_QxT56qUhdrgVwbT6Z_rzhwHFzIMbm5biJI-ZJ_
+RwNs5FgbzL7-fJGqvVgrzJd-eBGu_lLpwpFySMa-pJVUr0VuurBh0dtQkjiVb1Rp7vBMdVwmT6qCrkIjk_n9wS_EJ9-rRl6t_rGeqCUjz_kJqdx-OzvwhrzD
+gOkNxvlM-_nIwxVQ-hxr9hz6_5BQcBVUuI-sDBWZR5i_xPSc_ShvSUlhvrp_v_sa-xzv_zR7l_t-dSz_zlj9pt_d_RU__dcMV-Vht_t-dVi_zlj9-x_c_Plt
+V-xsxz__lTDFElunxoST_vht0uv_Vj8FEFxzGJzf_iEydpJ_PTuFcF_qIJzW_ji7_QJvZ_D-olpNUJzf_k_hl-RzjFd_i_v3__uf7WVpowSyu7SbnVyLhVqk
+GlaThlmkWVaZNZw0w7V-l_aTn_fDoFshdkmt8_ElCRpVajpl4DzlJEft0EiFGFO7W-5-K_DVmltvTJeO1lJdzsc1dkzVUVP7UhxVZS5FU7_-d7PPSRBVKFi3
+_Kb-O-sFGto_YvSl1_apZO9zPM1_xf4EzESW_T_yx-NV9FZ-9iFtLoc-ludn_KsGxs-YV7yLvllJDD_VTj7zVHFTt_V0_NqDs1-N_B6Mweyh_beFzmUye8dd
+J_F96A8_JMUZcFvh40RqNvF-2-JFbv4JuVl_QQU-ZXk0WHY8eeFjlrhd79I58G_OVrjwq0q9zLF_Mv5-wlyeq4-oltw-b-Mldvyb-Ukd_fyb-Qd_Tod--gd_
+hrByrFzt6Nxg_wy4Fyd--ZdOS7_z7Cdhhn-ld_3VdwEDzhER7xiV6z_lPpy_k_lPpSzQVjnyd7na780Jy_Bb-Zxu_Tp43oQ_Vt3ZgupHVnwBrTA1xl11B9VJ
+NxzOBezVoZu0lPVfbx8FG8e-0Atin-6FFW3Ldpo0VfRbbw87KFqx3t2d_vno0Fgl3ByKFO0EDT-l8yr-0NMyoGUWKvhhrudD741dDC-lCvlr0kg2vXo0Bcs2
+NrUsym2AhxNMMckjjTPQQ-qH
+}
+
 skinparam dpi 300
 allow_mixing
 
-skinparam node {
-	ArrowColor aqua
+skinparam defaultFontName "Open Sans"
+skinparam defaultFontColor QUARKUS_NEAR_BLACK
+skinparam defaultFontSize 14
+skinparam shadowing true
+skinparam shadowColor #DDDDDD
+skinparam roundCorner 10
 
-	borderColor #566573
-	backgroundColor #F9E79F
-	fontName Calibri
-	fontSize 17
-	fontColor #566573
+skinparam node {
+    borderColor DARK_BLUE_GRAY
+    backgroundColor LIGHT_BLUE
+    fontName "Open Sans"
+    fontSize 17
+    fontColor DARK_BLUE_GRAY
+    roundCorner 10
 }
 
 skinparam database {
-	borderColor #566573
-	backgroundColor #D5F5E3
+    borderColor DARK_BLUE_GRAY
+    backgroundColor #A8C4E0
+    fontColor DARK_BLUE_GRAY
 }
 
 skinparam agent {
-    backgroundColor<<frontend>> #D2B4DE
-    backgroundColor<<application>> #FAE5D3
+    backgroundColor<<frontend>> QUARKUS_BLUE
+    fontColor<<frontend>> #FFFFFF
+    borderColor<<frontend>> DARK_BLUE_GRAY
+    backgroundColor<<application>> WARM_GRAY
+    fontColor<<application>> QUARKUS_NEAR_BLACK
+    borderColor<<application>> WARM_GRAY_BORDER
 }
 
 skinparam arrow {
-  fontName Calibri
-  color #FF6655
-  fontColor #777777
-  thickness 2
-  fontSize 11
+    fontName "Open Sans"
+    color QUARKUS_RED
+    fontColor LABEL_GRAY
+    thickness 2
+    fontSize 13
 }
 
 skinparam class {
-  backgroundColor #FAE5D3
+    backgroundColor WARM_GRAY
+    borderColor WARM_GRAY_BORDER
+    fontColor QUARKUS_NEAR_BLACK
+    attributeFontColor QUARKUS_NEAR_BLACK
+    attributeFontName "Open Sans"
+}
+
+skinparam component {
+    backgroundColor MEDIUM_BLUE
+    borderColor DARK_BLUE_GRAY
+    fontColor #FFFFFF
+}
+
+skinparam package {
+    borderColor DARK_BLUE_GRAY
+    backgroundColor PALE_BLUE
+    fontColor DARK_BLUE_GRAY
+    fontSize 14
+    style rectangle
+}
+
+skinparam hexagon {
+    backgroundColor LIGHT_PURPLE
+    borderColor DARK_PURPLE
+    fontColor QUARKUS_NEAR_BLACK
+}
+
+skinparam cloud {
+    backgroundColor LIGHT_GRAY
+    borderColor DARK_BLUE_GRAY
+    fontColor QUARKUS_NEAR_BLACK
+}
+
+skinparam interface {
+    backgroundColor QUARKUS_BLUE
+    borderColor DARK_BLUE_GRAY
+    fontColor DARK_BLUE_GRAY
+}
+
+skinparam sequence {
+    lifeLineBorderColor DARK_BLUE_GRAY
+    lifeLineBackgroundColor PALE_BLUE
+    activationBackgroundColor LIGHT_BLUE
+    activationBorderColor DARK_BLUE_GRAY
 }


### PR DESCRIPTION
I've long been troubled by how unattractive our diagrams are. I've updated the colours, which helps a bit. I also added Quarkus logos for fun. :) 

Update all diagrams to use Quarkus brand colors (Blue #4695EB, Red #FF004A), Open Sans font, and consistent element styling. Add embedded Quarkus logo sprite to agent labels via QUARKUS_ICON define. Style REST interface circles, class spots, sequence diagram lifelines, and activation bars.

We may want to go away from handwritten, which is nothing like as good as excalidraw's, but I'll do this batch first. 

### Before:

<img width="310" height="326" alt="image" src="https://github.com/user-attachments/assets/e6d6f762-5e77-427c-ab9e-4b329ad1de3d" />

### After:

<img width="945" height="716" alt="image" src="https://github.com/user-attachments/assets/e60df88c-1f77-4879-bafe-8e7643b37da4" />

(these are different image files, hence the different contents!)