### PR TITLE
More diagram styling: Remove handwritten style and use rectangles instead of nodes

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture-ai.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture-ai.puml
@@ -3,23 +3,23 @@
 
 left to right direction
 
-node "Super Hero UI" as ui {
+rectangle "Super Hero UI" as ui {
     agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-node "Narration" as narration {
+rectangle "Narration" as narration {
     agent "QUARKUS_ICON Quarkus" <<application>> as narrationQuarkus
     hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
@@ -31,7 +31,7 @@ cloud "Open AI \n Azure OpenAI" as openai
 cloud "LLM Provider \n (OpenAI, Ollama, etc.)" as openai
 !endif
 
-node "Fight" as fight {
+rectangle "Fight" as fight {
     agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
@@ -49,10 +49,10 @@ package "stats" {
     }
 }
 
-node "Kafka + Zookeeper" as kafka {
+rectangle "Kafka + Zookeeper" as kafka {
 }
 
-node "Prometheus" as prometheus {
+rectangle "Prometheus" as prometheus {
 }
 
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture.puml
@@ -3,23 +3,23 @@
 
 left to right direction
 
-node "Super Hero UI" as ui {
+rectangle "Super Hero UI" as ui {
     agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-node "Fight" as fight {
+rectangle "Fight" as fight {
     agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
@@ -37,10 +37,10 @@ package "stats" {
     }
 }
 
-node "Kafka + Zookeeper" as kafka {
+rectangle "Kafka + Zookeeper" as kafka {
 }
 
-node "Prometheus" as prometheus {
+rectangle "Prometheus" as prometheus {
 }
 
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/1-rest-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/1-rest-physical-architecture.puml
@@ -3,7 +3,7 @@
 
 left to right direction
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/3-reactive-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/3-reactive-physical-architecture.puml
@@ -3,7 +3,7 @@
 
 left to right direction
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/4-microservices-physical-architecture.puml
@@ -3,23 +3,23 @@
 
 left to right direction
 
-node "Super Hero UI" as ui {
+rectangle "Super Hero UI" as ui {
     agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-node "Fight" as fight {
+rectangle "Fight" as fight {
     agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5-rest-client-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5-rest-client-physical-architecture.puml
@@ -3,23 +3,23 @@
 
 left to right direction
 
-node "Super Hero UI" as ui {
+rectangle "Super Hero UI" as ui {
     agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-node "Fight" as fight {
+rectangle "Fight" as fight {
     agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5a-ai-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5a-ai-physical-architecture.puml
@@ -3,23 +3,23 @@
 
 left to right direction
 
-node "Super Hero UI" as ui {
+rectangle "Super Hero UI" as ui {
     agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-node "Narration" as narration {
+rectangle "Narration" as narration {
     agent "QUARKUS_ICON Quarkus" <<application>> as narrationQuarkus
     hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk
@@ -31,7 +31,7 @@ cloud "Open AI \n Azure OpenAI" as openai
 cloud "LLM Provider \n (OpenAI, Ollama, Gemini, etc.)" as openai
 !endif
 
-node "Fight" as fight {
+rectangle "Fight" as fight {
     agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5b-ai-narration-microservice.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/5b-ai-narration-microservice.puml
@@ -3,7 +3,7 @@
 
 left to right direction
 
-node "Narration" as hero {
+rectangle "Narration" as hero {
     agent "QUARKUS_ICON Quarkus" <<application>> as narrationQuarkus
     hexagon "LangChain4j" as sk
     narrationQuarkus .up> sk

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/6-messaging-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/6-messaging-physical-architecture.puml
@@ -3,23 +3,23 @@
 
 left to right direction
 
-node "Super Hero UI" as ui {
+rectangle "Super Hero UI" as ui {
     agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-node "Fight" as fight {
+rectangle "Fight" as fight {
     agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
@@ -37,7 +37,7 @@ package "stats" {
     }
 }
 
-node "Kafka + Zookeeper" as kafka {
+rectangle "Kafka + Zookeeper" as kafka {
 }
 
 uiQuarkus --> fightQuarkus : HTTP

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/7-observability-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/7-observability-physical-architecture.puml
@@ -3,23 +3,23 @@
 
 left to right direction
 
-node "Super Hero UI" as ui {
+rectangle "Super Hero UI" as ui {
     agent "QUARKUS_ICON Quarkus" <<frontend>> as uiQuarkus
 }
 
-node "Hero" as hero {
+rectangle "Hero" as hero {
     agent "QUARKUS_ICON Quarkus (reactive)" <<application>> as heroQuarkus
     database "Postgresql" as heroPostgresql
     heroQuarkus .up> heroPostgresql
 }
 
-node "Villain" as villain {
+rectangle "Villain" as villain {
     agent "QUARKUS_ICON Quarkus (imperative)" <<application>> as villainQuarkus
     database "Postgresql" as villainPostgresql
     villainQuarkus .up> villainPostgresql
 }
 
-node "Fight" as fight {
+rectangle "Fight" as fight {
     agent "QUARKUS_ICON Quarkus" <<application>> as fightQuarkus
     database "Postgresql" as fightPostgresql
     fightQuarkus .up> fightPostgresql
@@ -37,10 +37,10 @@ package "stats" {
     }
 }
 
-node "Kafka + Zookeeper" as kafka {
+rectangle "Kafka + Zookeeper" as kafka {
 }
 
-node "Prometheus" as prometheus {
+rectangle "Prometheus" as prometheus {
 }
 
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/style.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/style.puml
@@ -49,6 +49,15 @@ skinparam node {
     roundCorner 10
 }
 
+skinparam rectangle {
+    borderColor DARK_BLUE_GRAY
+    backgroundColor LIGHT_BLUE
+    fontName "Open Sans"
+    fontSize 17
+    fontColor DARK_BLUE_GRAY
+    roundCorner 10
+}
+
 skinparam database {
     borderColor DARK_BLUE_GRAY
     backgroundColor #A8C4E0

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/themes/puml-theme-handwritten.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/themes/puml-theme-handwritten.puml
@@ -1,1 +1,1 @@
-!option handwritten true
+


### PR DESCRIPTION
The handwritten PlantUML theme doesn't match the Quarkus styling, and to be honest, it looks low-effort and doesn't really match anything, including genuinely hand-drawn things.
I also felt there was a lot of pointless three-dimensionality. That can't be fixed with styling, only by swapping `node` elements for `rectangles` (and then adding skinparams for rectangles). 

### Before: 

<img width="1722" height="1323" alt="image" src="https://github.com/user-attachments/assets/0c10f217-0fca-4e99-a85f-bcab423ccdbc" />


### After: 

<img width="2563" height="2743" alt="image" src="https://github.com/user-attachments/assets/3e26b5e6-5fdb-4370-b4d6-d43806383f9b" />

WDYT, @insectengine and @geoand?

Once we're happy with this I'll share it as a theme so we can have common styling across our estate. 