### PR TITLE
Do not wait for main code build to test docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           if-no-files-found: error
           retention-days: 3
   publication:
-    needs: [ docs, build_java17 ]
+    needs: [ docs ]
     runs-on: ubuntu-latest
     steps:
       - name: Download default site
@@ -180,7 +180,7 @@ jobs:
           retention-days: 7
   deploy:
     if: "github.ref_name == 'main' && (github.event_name == 'push' || github.event_name == 'schedule')"
-    needs: [ publication, test-docs ]
+    needs: [ publication, test-docs, build_java17 ]
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Now that the docs build and testing is so fast (yay!), the build of the main code is the slowest part of the build. We don't need to wait for that before uploading the site artifacts and running the test on the assembled docs. 

Should get the build from ~30m to ~20m. 

At the beginning of this week the build was 3.5 hours. 💪