### PR TITLE
Only install headless chromium

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Playwright
         run: |
           cd quarkus-workshop-super-heroes/docs
-          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.classpathScope=test -D exec.args="install --with-deps chromium"
+          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.classpathScope=test -D exec.args="install --with-deps --only-shell chromium"
       - name: Build and test site
         run: |
           cd quarkus-workshop-super-heroes/docs
@@ -160,7 +160,7 @@ jobs:
       - name: Install Playwright
         run: |
           cd quarkus-workshop-super-heroes/docs
-          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.classpathScope=test -D exec.args="install --with-deps chromium"
+          mvn exec:java -e -D exec.mainClass=com.microsoft.playwright.CLI -D exec.classpathScope=test -D exec.args="install --with-deps --only-shell chromium"
       - name: Run documentation tests
         run: |
           cd quarkus-workshop-super-heroes/docs


### PR DESCRIPTION
We have an annoying warning in our CI runs about Chromium dependencies. Sadly, this does not actually fix it, but it does reduce the download size a bit. 