### PR TITLE
Tactically remove Kafka dependencies from source tree, and make node.js config manual

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui.adoc
@@ -31,6 +31,36 @@ All the React code (graphical components, model, services) is located under `src
 
 We don't need to worry too much about the React code.
 
+ifdef::use-locked-down[]
+==== Installing the Node dependencies
+
+Quinoa can download and manage a local copy of Node.js for you, but this workshop disables that behaviour (`quarkus.quinoa.package-manager-install=false` in the `application.properties`) so that it works in locked-down environments where downloads from `nodejs.org` are blocked and where you are expected to use your organisation's own npm registry.
+
+This means you need to install the Node dependencies yourself before starting the application.
+
+[example, role="cta"]
+--
+First, make sure https://nodejs.org/[Node.js] (which includes `npm`) is installed and available on your `PATH`. You can check with:
+
+[source,shell]
+----
+node --version
+npm --version
+----
+
+Then, from the `ui-super-heroes` directory, download the Node dependencies into `src/main/webui/node_modules`:
+
+[source,shell]
+----
+npm --prefix src/main/webui install
+----
+--
+
+TIP: If your organisation provides its own npm registry, configure it (for example in an `.npmrc` file or via `npm config set registry`) before running the install so that the dependencies are fetched from the approved source.
+
+Once the dependencies are present, Quinoa will use them (and your system `npm`) rather than trying to download Node.js itself.
+endif::use-locked-down[]
+
 [example, role="cta"]
 --
 From the `ui-super-heroes`
@@ -61,6 +91,7 @@ endif::use-gradle[]
 Be sure you have the hero, villain and fights microservices running (dev mode is enough).
 --
 
+ifndef::use-locked-down[]
 If you don't have Node installed, Quinoa will install it during the start process (under the `.quinoa` directory).
 
 ----
@@ -68,6 +99,7 @@ INFO  [com.git.eir.mav.plu.fro.lib.NodeInstaller] (build-40) Installing node ver
 INFO  [com.git.eir.mav.plu.fro.lib.NodeInstaller] (build-40) Extracting NPM
 INFO  [com.git.eir.mav.plu.fro.lib.NodeInstaller] (build-40) Installed node locally.
 ----
+endif::use-locked-down[]
 
 You should see console output like the following
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-sending-to-kafka.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-sending-to-kafka.adoc
@@ -196,7 +196,8 @@ For this, edit the `application.properties` file and add the following propertie
 
 [source,properties]
 ----
-include::{projectdir}/rest-fights/src/main/resources/application.properties[tag=adocKafka]
+mp.messaging.outgoing.fights.connector=smallrye-kafka
+mp.messaging.outgoing.fights.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
 ----
 --
 

--- a/quarkus-workshop-super-heroes/docs/src/resource-generation/variants-config.json
+++ b/quarkus-workshop-super-heroes/docs/src/resource-generation/variants-config.json
@@ -51,6 +51,14 @@
             "standalone": true
         },
         {
+            "id": "locked-down",
+            "label": "Locked-down environment (manual Node install, own npm registry)",
+            "enabled": false,
+            "defaultValue": true,
+            "requires": [],
+            "standalone": false
+        },
+        {
             "id": "kubernetes",
             "label": "Running Quarkus on Kubernetes",
             "enabled": true,

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/build.gradle.kts
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
     implementation("io.quarkus:quarkus-hibernate-orm-panache")
     implementation("io.quarkus:quarkus-hibernate-validator")
     implementation("io.quarkus:quarkus-smallrye-openapi")
-    implementation("io.quarkus:quarkus-messaging-kafka") // Optional: only needed if you are doing the messaging section
     implementation("io.quarkus:quarkus-rest-jackson")
     implementation("io.quarkus:quarkus-jdbc-postgresql")
     implementation("io.quarkus:quarkus-arc")

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/pom.xml
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/pom.xml
@@ -60,11 +60,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
-        <!-- Optional: only needed if you are doing the messaging section -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-messaging-kafka</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/java/io/quarkus/workshop/superheroes/fight/FightService.java
@@ -3,8 +3,6 @@ package io.quarkus.workshop.superheroes.fight;
 
 import io.quarkus.workshop.superheroes.fight.client.*;
 import org.eclipse.microprofile.faulttolerance.Fallback;
-import org.eclipse.microprofile.reactive.messaging.Channel;
-import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.logging.Logger;
 
@@ -40,9 +38,6 @@ public class FightService {
     // end::adocNarrate[]
 
     private final Random random = new Random();
-
-    @Channel("fights")
-    Emitter<Fight> emitter;
 
     public List<Fight> findAllFights() {
         return Fight.listAll();
@@ -112,9 +107,6 @@ public class FightService {
 
         fight.fightDate = Instant.now();
         fight.persist();
-
-        logger.info("Fight sent to statistics");
-        emitter.send(fight).toCompletableFuture().join();
 
         return fight;
     }

--- a/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/resources/application.properties
+++ b/quarkus-workshop-super-heroes/super-heroes/rest-fights/src/main/resources/application.properties
@@ -34,11 +34,6 @@ quarkus.rest-client.villain.url=http://localhost:8084
 quarkus.rest-client.narration.url=http://localhost:8086
 # end::adocNarrate[]
 
-## Kafka configuration
-# tag::adocKafka[]
-mp.messaging.outgoing.fights.connector=smallrye-kafka
-mp.messaging.outgoing.fights.value.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
-# end::adocKafka[]
 
 # tag::adocCORS[]
 ## CORS

--- a/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/resources/application.properties
+++ b/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes/src/main/resources/application.properties
@@ -1,3 +1,2 @@
-quarkus.quinoa.package-manager-install=true
-quarkus.quinoa.package-manager-install.node-version=16.16.0
+quarkus.quinoa.package-manager-install=false
 api.base.url=http://localhost:8082


### PR DESCRIPTION
See #749 and #750

These changes should be reverted when the planned workshop has been delivered (except for 4bcdd897ea4c60cee09c11b273de26fd802b2089, which we will want to keep for #751).