### PR TITLE
Exclude messaging and observability from the architecture diagram if unused

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture.puml
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/plantuml/0-introduction-physical-architecture.puml
@@ -39,6 +39,7 @@ rectangle "Fight" as fight {
     fightQuarkus .up> fightPostgresql
 }
 
+!ifdef use_messaging
 package "stats" {
     node "Statistics" as stat {
         agent "HTML+JQuery" <<frontend>> as statUI
@@ -50,12 +51,17 @@ package "stats" {
             agent "Browser" <<frontend>> as uiStats
     }
 }
+!endif
 
+!ifdef use_messaging
 rectangle "Kafka + Zookeeper" as kafka {
 }
+!endif
 
+!ifdef use_observability
 rectangle "Prometheus" as prometheus {
 }
+!endif
 
 
 uiQuarkus --> fightQuarkus : HTTP
@@ -67,11 +73,15 @@ fightQuarkus --> narrationQuarkus : HTTP
 sk --> openai : HTTP
 !endif
 
+!ifdef use_messaging
 fightQuarkus ..> kafka : Message
 stat <.. kafka : Message
 statQuarkus ..> uiStats : Web Sockets
+!endif
 
+!ifdef use_observability
 prometheus .down.> fight : polling
 prometheus  .> hero : polling
 prometheus .> villain : polling
+!endif
 @enduml

--- a/quarkus-workshop-super-heroes/docs/src/resource-generation/generate-variants.java
+++ b/quarkus-workshop-super-heroes/docs/src/resource-generation/generate-variants.java
@@ -232,13 +232,19 @@ class generate_variants {
     }
 
     // Only flags that appear in !ifdef guards in .puml files need distinct diagram directories.
-    // Currently: ai and azure. Update if new !ifdef guards are added to .puml files.
+    // Currently: ai, azure, messaging and observability. Update if new !ifdef guards are added to .puml files.
     private static String diagramKey(Map<String, Boolean> assignment) {
         boolean ai = Boolean.TRUE.equals(assignment.get("ai"));
         boolean azure = Boolean.TRUE.equals(assignment.get("azure"));
-        if (ai && azure) return "ai-azure";
-        if (ai) return "ai";
-        return "base";
+        boolean messaging = Boolean.TRUE.equals(assignment.get("messaging"));
+        boolean observability = Boolean.TRUE.equals(assignment.get("observability"));
+        List<String> parts = new ArrayList<>();
+        // azure only changes a diagram in combination with ai
+        if (ai && azure) parts.add("ai-azure");
+        else if (ai) parts.add("ai");
+        if (messaging) parts.add("msg");
+        if (observability) parts.add("obs");
+        return parts.isEmpty() ? "base" : String.join("-", parts);
     }
 
     private static void copyStaticImages(String srcDir, String destDir,


### PR DESCRIPTION
The base architecture diagram still had observability and messaging elements even when they weren't used.