### PR TITLE
Document customising Dev Services images in locked-down environments

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-microservices/microservices-fight.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-microservices/microservices-fight.adoc
@@ -671,6 +671,10 @@ Then, make sure the tests pass by executing the command `./gradlew test` (or fro
 endif::use-gradle[]
 Quarkus automatically starts the PostGreSQL database.
 
+ifdef::use-locked-down[]
+TIP: If your environment only allows specific images, you can change the database image with `quarkus.datasource.devservices.image-name` in your `application.properties` (for example `quarkus.datasource.devservices.image-name=registry.example.com/postgres:16`).
+endif::use-locked-down[]
+
 Now that the tests are green, we are ready to run our application.
 ifdef::use-maven[]
 Use `./mvnw quarkus:dev` to start it (notice that there is no banner yet, it will come later).

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-orm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-orm.adoc
@@ -321,6 +321,22 @@ In the log, you will see the following:
 Quarkus detects the need for a database and starts one using a Docker container.
 It automatically configures the application, which means we are good to go and implement our REST API.
 
+ifdef::use-locked-down[]
+[TIP]
+====
+By default, Dev Services pulls the `postgres` image from Docker Hub.
+If your environment only allows specific images (for example, images from an approved internal registry), you can adjust the image being used by setting the `quarkus.datasource.devservices.image-name` property in your `application.properties`:
+
+[source,properties]
+----
+quarkus.datasource.devservices.image-name=registry.example.com/postgres:16
+----
+
+Replace `registry.example.com/postgres:16` with an image that is approved for your environment.
+The same approach works for other Dev Services (for example `quarkus.kafka.devservices.image-name` or `quarkus.redis.devservices.image-name`); each extension exposes its own `image-name` property.
+====
+endif::use-locked-down[]
+
 [NOTE]
 ====
 If the application fails to start properly and the logs contain something like

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-sending-to-kafka.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-messaging/messaging-sending-to-kafka.adoc
@@ -147,6 +147,10 @@ Quarkus starts a Kafka broker automatically.
 You can check that by executing the `docker container ls` command.
 ====
 
+ifdef::use-locked-down[]
+TIP: If your environment only allows specific images, you can change the broker image with `quarkus.kafka.devservices.image-name` in your `application.properties` (for example `quarkus.kafka.devservices.image-name=registry.example.com/redpanda:latest`).
+endif::use-locked-down[]
+
 == Connecting Imperative and Reactive Using an Emitter
 
 [example, role="cta"]


### PR DESCRIPTION
Guarded by the use-locked-down AsciiDoc attribute, explain how to point Dev Services at an approved image when the environment only allows specific images. Add a fuller explanation next to the PostgreSQL Dev Service in rest-orm.adoc, and shorter one-line TIPs where the fight microservice starts PostgreSQL and where the messaging chapter starts the Kafka broker.