### PR TITLE
Show locked-down variant as a default-off toggle in its own section

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html.template
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/index.html.template
@@ -28,6 +28,10 @@
         const enabledFlags = allFlags.filter(f => f.enabled);
         const nonStandaloneFlags = enabledFlags.filter(f => !f.standalone);
         const standaloneFlags = enabledFlags.filter(f => f.standalone);
+        // Non-standalone flags without a section are regular "content" checkboxes; those with a
+        // section (e.g. locked-down -> "Environment") are rendered under their own heading instead.
+        const contentFlags = nonStandaloneFlags.filter(f => !f.section);
+        const sectionedFlags = nonStandaloneFlags.filter(f => f.section);
 
         const baseUrl = "./";
         const filename = "spine.html";
@@ -273,6 +277,9 @@
         <!-- Checkboxes are generated dynamically from variants-config.json -->
         <ul class="configurator" id="feature-checkboxes"></ul>
 
+        <!-- Flags with a "section" (e.g. locked-down) are rendered here, each under its own heading -->
+        <div id="custom-sections"></div>
+
         <div id="standalone-section" style="display:none">
             <h4 class="no-underline" id="standalone-selector"><i class="fas fa-puzzle-piece"></i>Standalone modules
             </h4>
@@ -286,45 +293,56 @@
 </div>
 
 <script>
+    // Create the <li> for a single flag checkbox
+    function createFlagCheckbox(flag) {
+        const li = document.createElement('li');
+        li.id = `use-${flag.id}-li`;
+        const label = document.createElement('label');
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.id = `use-${flag.id}`;
+        input.addEventListener('change', () => onCheckboxChange(flag.id));
+        label.appendChild(input);
+        let labelText = flag.label;
+        if (flag.requires && flag.requires.length > 0) {
+            labelText += ` (needs ${flag.requires.join(', ')})`;
+        }
+        label.appendChild(document.createTextNode(labelText));
+        li.appendChild(label);
+        return li;
+    }
+
     // Build checkboxes dynamically from config
     function buildCheckboxes() {
         const featureList = document.getElementById('feature-checkboxes');
+        const customSections = document.getElementById('custom-sections');
         const standaloneList = document.getElementById('standalone-checkboxes');
         const standaloneSection = document.getElementById('standalone-section');
 
-        nonStandaloneFlags.forEach(flag => {
-            const li = document.createElement('li');
-            li.id = `use-${flag.id}-li`;
-            const label = document.createElement('label');
-            const input = document.createElement('input');
-            input.type = 'checkbox';
-            input.id = `use-${flag.id}`;
-            input.addEventListener('change', () => onCheckboxChange(flag.id));
-            label.appendChild(input);
-            let labelText = flag.label;
-            if (flag.requires.length > 0) {
-                labelText += ` (needs ${flag.requires.join(', ')})`;
+        contentFlags.forEach(flag => featureList.appendChild(createFlagCheckbox(flag)));
+
+        // Group sectioned flags by their section name and render each under its own heading
+        const sectionLists = {};
+        sectionedFlags.forEach(flag => {
+            if (!sectionLists[flag.section]) {
+                const heading = document.createElement('h4');
+                heading.className = 'no-underline';
+                const icon = document.createElement('i');
+                icon.className = 'fas fa-lock';
+                heading.appendChild(icon);
+                heading.appendChild(document.createTextNode(flag.section));
+                customSections.appendChild(heading);
+                const ul = document.createElement('ul');
+                ul.className = 'configurator';
+                customSections.appendChild(ul);
+                sectionLists[flag.section] = ul;
             }
-            label.appendChild(document.createTextNode(labelText));
-            li.appendChild(label);
-            featureList.appendChild(li);
+            sectionLists[flag.section].appendChild(createFlagCheckbox(flag));
         });
 
         if (standaloneFlags.length > 0) {
             standaloneSection.style.display = '';
-            standaloneFlags.forEach(flag => {
-                const li = document.createElement('li');
-                li.id = `use-${flag.id}-li`;
-                const label = document.createElement('label');
-                const input = document.createElement('input');
-                input.type = 'checkbox';
-                input.id = `use-${flag.id}`;
-                input.addEventListener('change', () => onCheckboxChange(flag.id));
-                label.appendChild(input);
-                label.appendChild(document.createTextNode(flag.label));
-                li.appendChild(label);
-                standaloneList.appendChild(li);
-            });
+            standaloneFlags.forEach(flag => standaloneList.appendChild(createFlagCheckbox(flag)));
         }
     }
 

--- a/quarkus-workshop-super-heroes/docs/src/resource-generation/variants-config.json
+++ b/quarkus-workshop-super-heroes/docs/src/resource-generation/variants-config.json
@@ -53,10 +53,11 @@
         {
             "id": "locked-down",
             "label": "Locked-down environment (manual Node install, own npm registry)",
-            "enabled": false,
-            "defaultValue": true,
+            "enabled": true,
+            "defaultValue": false,
             "requires": [],
-            "standalone": false
+            "standalone": false,
+            "section": "Environment"
         },
         {
             "id": "kubernetes",

--- a/quarkus-workshop-super-heroes/docs/src/resource-generation/variants-config.json
+++ b/quarkus-workshop-super-heroes/docs/src/resource-generation/variants-config.json
@@ -52,7 +52,7 @@
         },
         {
             "id": "locked-down",
-            "label": "Locked-down environment (manual Node install, own npm registry)",
+            "label": "Locked-down environment",
             "enabled": true,
             "defaultValue": false,
             "requires": [],

--- a/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/ConfiguratorTest.java
+++ b/quarkus-workshop-super-heroes/docs/src/test/java/io/quarkus/workshop/docs/ConfiguratorTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import com.microsoft.playwright.Locator;
@@ -334,6 +335,11 @@ public class ConfiguratorTest extends DocumentationTestBase {
         }
     }
 
+    // Flags whose content is not a spine-level include but is guarded inline inside an
+    // always-included core file (e.g. locked-down lives in core-ui/ui.adoc), so they legitimately
+    // have no ifdef block in spine.adoc.
+    private static final Set<String> INLINE_GUARDED_FLAGS = Set.of("locked-down");
+
     @Test
     @DisplayName("spine.adoc should have ifdef blocks for every enabled flag")
     void testSpineAdocHasAllFlags() throws Exception {
@@ -347,6 +353,9 @@ public class ConfiguratorTest extends DocumentationTestBase {
         VariantsConfig config = VariantsConfig.load();
 
         for (VariantsConfig.Flag flag : config.enabledFlags()) {
+            if (INLINE_GUARDED_FLAGS.contains(flag.id())) {
+                continue;
+            }
             assertTrue(spineContent.contains("ifdef::use-" + flag.id() + "[]"),
                 "spine.adoc should have ifdef::use-" + flag.id() + "[] block");
         }


### PR DESCRIPTION
Resolves #751 

Enable the locked-down flag so it appears in the configurator UI, defaulting to false so the workshop is not locked down unless explicitly selected.

Render it under its own "Environment" heading rather than in the content checkbox list, via a new optional "section" field on flags. It remains a non-standalone flag, so the existing constraint/select-all logic and variant generation are unaffected; the field is presentational only and ignored by the Java parsers.

Exclude locked-down from testSpineAdocHasAllFlags: unlike the section-include flags, its content is guarded inline in the always-included core-ui/ui.adoc, so it has no ifdef block in spine.adoc.