### PR TITLE
Add no-zip guidance for security-conscious environments

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/common-no-zip-download.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/common-no-zip-download.adoc
@@ -1,0 +1,9 @@
+ifdef::use-no-zip[]
+[NOTE]
+.Working without the zip
+====
+In some security-conscious environments, downloading the zip isn't an option.
+If that's a constraint you have, you can follow the workshop without it.
+We'll fill in the gaps as we go, showing you how to create the pieces the zip would have provided (and, where a piece is too big to paste, how to copy it from source control).
+====
+endif::use-no-zip[]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/common-no-zip-infrastructure.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/common-no-zip-infrastructure.adoc
@@ -1,0 +1,59 @@
+ifdef::use-no-zip[]
+[TIP]
+.Working without the zip
+====
+The workshop zip provides a `super-heroes/infrastructure` directory.
+If downloading it isn't an option for you, create that directory yourself and add the files below.
+They are exactly the files the zip would have given you, so you can copy and paste them.
+
+.super-heroes/infrastructure/docker-compose.yaml
+[source,yaml]
+----
+include::{projectdir}/infrastructure/docker-compose.yaml[]
+----
+
+ifdef::use-linux[]
+.super-heroes/infrastructure/docker-compose-linux.yaml
+[source,yaml]
+----
+include::{projectdir}/infrastructure/docker-compose-linux.yaml[]
+----
+endif::use-linux[]
+
+ifdef::use-messaging[]
+.super-heroes/infrastructure/docker-compose-kafka.yaml
+[source,yaml]
+----
+include::{projectdir}/infrastructure/docker-compose-kafka.yaml[]
+----
+endif::use-messaging[]
+
+.super-heroes/infrastructure/db-init/initialize-databases.sql
+[source,sql]
+----
+include::{projectdir}/infrastructure/db-init/initialize-databases.sql[]
+----
+
+.super-heroes/infrastructure/monitoring/prometheus.yml
+[source,yaml]
+----
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+include::{projectdir}/infrastructure/monitoring/prometheus.yml[tags=adocPrometheus]
+----
+
+ifdef::use-linux[]
+.super-heroes/infrastructure/monitoring/prometheus-linux.yml
+[source,yaml]
+----
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+include::{projectdir}/infrastructure/monitoring/prometheus-linux.yml[tags=adocPrometheus]
+----
+endif::use-linux[]
+
+Once these files are in place, the `docker compose` commands below will work exactly as they would have with the zip.
+====
+endif::use-no-zip[]

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-docker.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-docker.adoc
@@ -14,6 +14,8 @@ Here, you will find a `docker-compose.yaml` or `docker-compose-linux.yaml` file 
 endif::use-mac+use-windows+use-linux[]
 Notice that there is a `db-init` directory with an `initialize-databases.sql` script which sets up our databases, and a `monitoring` directory (all that will be explained later).
 
+include::../common-no-zip-infrastructure.adoc[]
+
 [role="cta"]
 ====
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-maven.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-appendix/appendix-preparing-warming-maven.adoc
@@ -10,6 +10,8 @@ First, download the zip file  {github-raw}/dist/quarkus-super-heroes-workshop.zi
 This zip file contains _some_ of the code of the workshop, and you will need to complete it.
 ====
 
+include::../common-no-zip-download.adoc[]
+
 == Download the Maven dependencies
 
 [role="cta"]
@@ -37,6 +39,8 @@ ifdef::use-gradle[]
 First, download the zip file  {github-raw}/dist/quarkus-super-heroes-workshop.zip, and unzip it wherever you want.
 This zip file contains _some_ of the code of the workshop, and you will need to complete it.
 ====
+
+include::../common-no-zip-download.adoc[]
 
 == Download the Gradle dependencies
 

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-preparing.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-preparing.adoc
@@ -27,6 +27,8 @@ This zip file contains _some_ of the code of the workshop, along with assets you
 
 --
 
+include::../common-no-zip-download.adoc[]
+
 === Super Heroes Application
 
 Under the `super-heroes` directory you will find the entire Super Hero application spread throughout a set of subdirectories, each one containing a microservice or some tooling.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-presentation.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-introduction/introduction-presentation.adoc
@@ -132,6 +132,8 @@ So your job is to follow the instructions by yourself, do what you are supposed 
 
 You will download a zip file ({github-raw}/dist/quarkus-super-heroes-workshop.zip[`quarkus-super-heroes-workshop.zip`]) containing _some_ of the code and you will need to complete it.
 
+include::../common-no-zip-download.adoc[]
+
 Oh, and be ready to have some fun!
 
 == Software Requirements

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-orm.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-rest/rest-orm.adoc
@@ -625,6 +625,8 @@ Let's use Docker and docker compose to ease the installation of such infrastruct
 
 You should already have installed the infrastructure into the `infrastructure` directory.
 
+include::../common-no-zip-infrastructure.adoc[]
+
 [example, role="cta"]
 --
 Now, just execute `docker compose -f docker-compose.yaml up -d` under the `infrastructure` directory.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/core-ui/ui.adoc
@@ -23,6 +23,25 @@ Quinoa is framework-agnostic, and works with React, Angular, Vue, Lit, and other
 Navigate to the `super-heroes/ui-super-heroes` directory.
 It contains the code of the application.
 
+ifdef::use-no-zip[]
+[TIP]
+.Working without the zip
+====
+Unlike the other pieces, the React front end is far too large to paste in here, so if downloading the zip isn't an option for you, copy the `ui-super-heroes` directory from source control instead.
+
+The whole workshop lives at {github-url}.
+You can browse to `quarkus-workshop-super-heroes/super-heroes/ui-super-heroes` and download that directory, or clone the repository and copy it into your `super-heroes` directory:
+
+[source,shell,subs="attributes+"]
+----
+git clone {github-repo}.git
+cp -r quarkus-workshops/quarkus-workshop-super-heroes/super-heroes/ui-super-heroes super-heroes/
+----
+
+If Git access is also restricted in your environment, ask a workshop facilitator for a copy of the `ui-super-heroes` directory.
+====
+endif::use-no-zip[]
+
 The React application is in `src/main/webui`.
 Being a React application, you will find a `package.json` file which defines all the needed dependencies.
 All the React code (graphical components, model, services) is located under `src/main/webui/src/app`.

--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/spine.adoc
@@ -62,6 +62,11 @@ endif::[]
 ifdef::use-locked-down[]
 :use-no-quarkus-cli:
 endif::use-locked-down[]
+// Likewise, a locked-down environment often can't download the workshop zip, so
+// locked-down implies no-zip. It too can be promoted to its own flag later if needed.
+ifdef::use-locked-down[]
+:use-no-zip:
+endif::use-locked-down[]
 // /!\ The document header may not contain empty lines. The first empty line the processor encounters after the document header begins marks the end of the document header and the start of the document body. https://docs.asciidoctor.org/asciidoc/latest/document/header/
 
 


### PR DESCRIPTION
Some attendees follow the workshop in environments where downloading the starter zip isn't an option. Add fallback guidance for that case, derived from the existing locked-down attribute.

- spine.adoc: derive :use-no-zip: from :use-locked-down: at the AsciiDoc level (no new doc variant, no generator/config changes).
- common-no-zip-download.adoc: note that the workshop can be followed without the zip; wired into the download sites.
- common-no-zip-infrastructure.adoc: copy-paste of the infra set via include:: of the real sources; wired into rest-orm and the docker warming appendix.
- ui.adoc: copy-from-source-control fallback for the React front end (too large to paste).

All fallbacks are guarded by ifdef::use-no-zip[], lead with the zip download first, and are phrased for security-conscious environments rather than assuming fault.