### PR TITLE
Do not use gradle commands for extension section of workshop

### DIFF
--- a/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-quarkus-extension/quarkus-extension.adoc
+++ b/quarkus-workshop-super-heroes/docs/src/docs/asciidoc/optional-quarkus-extension/quarkus-extension.adoc
@@ -12,7 +12,6 @@ ifdef::use-gradle[]
 Quarkus extension development currently requires Maven.
 Even if you use Gradle for your applications, you will need Maven for this chapter.
 The extension creation command and multi-module structure rely on Maven.
-However, simple build and dev-mode commands have Gradle equivalents shown below.
 ====
 endif::use-gradle[]
 
@@ -77,7 +76,8 @@ endif::use-maven[]
 ifdef::use-gradle[]
 [.tab-gradle]
 --
-NOTE: Extension creation requires Maven. Use the Maven wrapper for this step:
+NOTE: Extension creation requires Maven.
+Use the Maven wrapper for this step:
 
 [source,shell,subs="attributes+"]
 ----
@@ -163,6 +163,7 @@ The _runtime_ part of an extension contains only the classes and resources requi
 For the version extension, it would be a single class that prints the version.
 
 First, let's create the configuration class that will allow users to dynamically configure whether the version should be printed:
+
 [role="cta"]
 ====
 Under the `runtime` module, create the `src/main/java` directory, and, in this directory, create a new interface named `io.quarkus.workshop.superheroes.version.runtime.VersionConfig` with the following content:
@@ -172,13 +173,16 @@ Under the `runtime` module, create the `src/main/java` directory, and, in this d
 include::{code-root}/extension-version/runtime/src/main/java/io/quarkus/workshop/superheroes/version/runtime/VersionConfig.java[]
 ----
 ====
-The `@ConfigMapping` annotation declares `VersionConfig` as a configuration interface which configuration properties are prefixed with `quarkus.version` prefix. It is also used in CDI aware environments to scan and register Config Mappings.
+
+The `@ConfigMapping` annotation declares `VersionConfig` as a configuration interface which configuration properties are prefixed with `quarkus.version` prefix.
+It is also used in CDI aware environments to scan and register Config Mappings.
 
 The `@ConfigRoot` annotation declares that the configuration is available during runtime.
 
 The `@WithDefault("true")` is used to declare the default value returned when `enabled()` is called.
 
-By default, the name of the property is derived from what's declared in the `prefix` attribute inside `@ConfigMapping` plus the name of the method. In our case, the user-configured property will be `quarkus.version.enabled`.
+By default, the name of the property is derived from what's declared in the `prefix` attribute inside `@ConfigMapping` plus the name of the method.
+In our case, the user-configured property will be `quarkus.version.enabled`.
 
 [role="cta"]
 ====
@@ -206,11 +210,12 @@ The version extension consists of a single build step that extracts the version 
 ====
 Next, open the `ExtensionVersionProcessor` class, and update the content to be:
 
-[source, java]
+[source,java]
 ----
 include::{code-root}/extension-version/deployment/src/main/java/io/quarkus/workshop/superheroes/version/deployment/ExtensionVersionProcessor.java[]
 ----
 ====
+
 This class is the core of the extension.
 It contains a set of methods annotated with `@BuildStep`.
 
@@ -244,23 +249,12 @@ Any invocations made on these proxies will be recorded, and bytecode will be wri
 ====
 From the root directory of the extension, run:
 
-ifdef::use-maven[]
-[.tab-maven]
 --
 [source,shell]
 ----
 ./mvnw clean install
 ----
---
-endif::use-maven[]
-ifdef::use-gradle[]
-[.tab-gradle]
---
-[source,shell]
-----
-./gradlew clean build
-----
---
+
 endif::use-gradle[]
 ====
 
@@ -293,29 +287,16 @@ endif::use-gradle[]
 
 If not yet started, start the microservice with:
 
-ifdef::use-maven[]
-[.tab-maven]
---
 [source,shell]
 ----
 ./mvnw quarkus:dev
 ----
---
-endif::use-maven[]
-ifdef::use-gradle[]
-[.tab-gradle]
---
-[source,shell]
-----
-./gradlew quarkusDev
-----
---
-endif::use-gradle[]
+
 ====
 
 And the version will be displayed:
 
-[source, text]
+[source,text]
 ----
 10:16:58 INFO  [io.qu.wo.su.ve.ru.VersionRecorder] (Quarkus Main Thread) Version: 1.0.0-SNAPSHOT
 ...


### PR DESCRIPTION
When running through the workshop today, I noticed that it provided gradle commands for the extension, which is a maven build. I assumed it was copy-paste, but when I went to remove it, I noticed that the text actually says there are gradle equivalents for simple maven commands. I checked, and the version of gradle I have definitely can't build a pom, so I suggest we just drop gradle in this section. 